### PR TITLE
feat: support getting provider configuration from stacklet-admin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ export STACKLET_ENDPOINT="https://api.<myinstance>.stacklet.io/"
 export STACKLET_API_KEY="your-api-key"
 ```
 
+### Login via stacklet-admin CLI
+
+The provider can look up authentication details from the [`stacklet-admin`](https://github.com/stacklet/stacklet-admin) CLI.
+
+After configuring and logging in to the instance via the CLI (`stacklet-admin login`), the provider will be able to connect
+to it.
+
 ### Testing with Local Provider
 
 1. After building and installing the provider locally (see [Building The Provider](#building-the-provider)), create a test directory:

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"flag"
 	"log"
 
-	"github.com/stacklet/terraform-provider-stacklet/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/stacklet/terraform-provider-stacklet/internal/provider"
 )
 
 // Run "go generate" to format example terraform files and generate the docs for the registry/website
@@ -41,4 +41,4 @@ func main() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-} 
+}


### PR DESCRIPTION
### what

support getting the endpoint and API key from the stacklet-admin
configuration (under `~/.stacklet`) as a fallback.

Configuration is looked up in env variables first, then provider configuration
and finally CLI configuration

### why

makes it easier for interactive use to run `stacklet-admin login` before
running `terraform`.

### testing

tested locally against sandbox

### docs

docs are updated here
