### PR TITLE
chore: add helper to split import IDs, use it everywhere

### DIFF
--- a/internal/acceptance_tests/recordings/TestAccAccountGroupMappingResource.json
+++ b/internal/acceptance_tests/recordings/TestAccAccountGroupMappingResource.json
@@ -85,27 +85,27 @@
           "addAccountGroup": {
             "group": {
               "description": "Test account group",
-              "id": "WyJhY2NvdW50LWdyb3VwIiwgIjA1NThjNzVhLTM5M2QtNDhlYS1iMmJjLWU2OTBlNzkyMTlkZCJd",
+              "id": "WyJhY2NvdW50LWdyb3VwIiwgIjU0ODgwYmUxLTliMjctNDUzZS1hZWNmLWJlNzQzNzQ2Y2Y0ZSJd",
               "name": "test-group-mappings",
               "provider": "AWS",
               "regions": [
                 "us-east-1"
               ],
-              "uuid": "0558c75a-393d-48ea-b2bc-e690e79219dd"
+              "uuid": "54880be1-9b27-453e-aecf-be743746cf4e"
             }
           }
         }
       }
     }
   ],
-  "mutation ($input:RemoveAccountGroupMappingsInput!){removeAccountGroupMappings(input: $input){removed{id}}}:{\"input\":{\"ids\":[\"WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiMDU1OGM3NWEtMzkzZC00OGVhLWIyYmMtZTY5MGU3OTIxOWRkIiwgIjExMTExMTExMTExMSJd\"]}}": [
+  "mutation ($input:RemoveAccountGroupMappingsInput!){removeAccountGroupMappings(input: $input){removed{id}}}:{\"input\":{\"ids\":[\"WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiNTQ4ODBiZTEtOWIyNy00NTNlLWFlY2YtYmU3NDM3NDZjZjRlIiwgIjExMTExMTExMTExMSJd\"]}}": [
     {
       "request": {
         "query": "mutation ($input:RemoveAccountGroupMappingsInput!){removeAccountGroupMappings(input: $input){removed{id}}}",
         "variables": {
           "input": {
             "ids": [
-              "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiMDU1OGM3NWEtMzkzZC00OGVhLWIyYmMtZTY5MGU3OTIxOWRkIiwgIjExMTExMTExMTExMSJd"
+              "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiNTQ4ODBiZTEtOWIyNy00NTNlLWFlY2YtYmU3NDM3NDZjZjRlIiwgIjExMTExMTExMTExMSJd"
             ]
           }
         }
@@ -115,7 +115,7 @@
           "removeAccountGroupMappings": {
             "removed": [
               {
-                "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiMDU1OGM3NWEtMzkzZC00OGVhLWIyYmMtZTY5MGU3OTIxOWRkIiwgIjExMTExMTExMTExMSJd"
+                "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiNTQ4ODBiZTEtOWIyNy00NTNlLWFlY2YtYmU3NDM3NDZjZjRlIiwgIjExMTExMTExMTExMSJd"
               }
             ]
           }
@@ -123,14 +123,14 @@
       }
     }
   ],
-  "mutation ($input:RemoveAccountGroupMappingsInput!){removeAccountGroupMappings(input: $input){removed{id}}}:{\"input\":{\"ids\":[\"WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiMDU1OGM3NWEtMzkzZC00OGVhLWIyYmMtZTY5MGU3OTIxOWRkIiwgIjIyMjIyMjIyMjIyMiJd\"]}}": [
+  "mutation ($input:RemoveAccountGroupMappingsInput!){removeAccountGroupMappings(input: $input){removed{id}}}:{\"input\":{\"ids\":[\"WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiNTQ4ODBiZTEtOWIyNy00NTNlLWFlY2YtYmU3NDM3NDZjZjRlIiwgIjIyMjIyMjIyMjIyMiJd\"]}}": [
     {
       "request": {
         "query": "mutation ($input:RemoveAccountGroupMappingsInput!){removeAccountGroupMappings(input: $input){removed{id}}}",
         "variables": {
           "input": {
             "ids": [
-              "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiMDU1OGM3NWEtMzkzZC00OGVhLWIyYmMtZTY5MGU3OTIxOWRkIiwgIjIyMjIyMjIyMjIyMiJd"
+              "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiNTQ4ODBiZTEtOWIyNy00NTNlLWFlY2YtYmU3NDM3NDZjZjRlIiwgIjIyMjIyMjIyMjIyMiJd"
             ]
           }
         }
@@ -140,7 +140,7 @@
           "removeAccountGroupMappings": {
             "removed": [
               {
-                "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiMDU1OGM3NWEtMzkzZC00OGVhLWIyYmMtZTY5MGU3OTIxOWRkIiwgIjIyMjIyMjIyMjIyMiJd"
+                "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiNTQ4ODBiZTEtOWIyNy00NTNlLWFlY2YtYmU3NDM3NDZjZjRlIiwgIjIyMjIyMjIyMjIyMiJd"
               }
             ]
           }
@@ -148,7 +148,7 @@
       }
     }
   ],
-  "mutation ($input:UpsertAccountGroupMappingsInput!){upsertAccountGroupMappings(input: $input){mappings{id}}}:{\"input\":{\"mappings\":[{\"accountKey\":\"111111111111\",\"groupUUID\":\"0558c75a-393d-48ea-b2bc-e690e79219dd\"}]}}": [
+  "mutation ($input:UpsertAccountGroupMappingsInput!){upsertAccountGroupMappings(input: $input){mappings{id}}}:{\"input\":{\"mappings\":[{\"accountKey\":\"111111111111\",\"groupUUID\":\"54880be1-9b27-453e-aecf-be743746cf4e\"}]}}": [
     {
       "request": {
         "query": "mutation ($input:UpsertAccountGroupMappingsInput!){upsertAccountGroupMappings(input: $input){mappings{id}}}",
@@ -157,7 +157,7 @@
             "mappings": [
               {
                 "accountKey": "111111111111",
-                "groupUUID": "0558c75a-393d-48ea-b2bc-e690e79219dd"
+                "groupUUID": "54880be1-9b27-453e-aecf-be743746cf4e"
               }
             ]
           }
@@ -168,7 +168,7 @@
           "upsertAccountGroupMappings": {
             "mappings": [
               {
-                "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiMDU1OGM3NWEtMzkzZC00OGVhLWIyYmMtZTY5MGU3OTIxOWRkIiwgIjExMTExMTExMTExMSJd"
+                "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiNTQ4ODBiZTEtOWIyNy00NTNlLWFlY2YtYmU3NDM3NDZjZjRlIiwgIjExMTExMTExMTExMSJd"
               }
             ]
           }
@@ -176,7 +176,7 @@
       }
     }
   ],
-  "mutation ($input:UpsertAccountGroupMappingsInput!){upsertAccountGroupMappings(input: $input){mappings{id}}}:{\"input\":{\"mappings\":[{\"accountKey\":\"222222222222\",\"groupUUID\":\"0558c75a-393d-48ea-b2bc-e690e79219dd\"}]}}": [
+  "mutation ($input:UpsertAccountGroupMappingsInput!){upsertAccountGroupMappings(input: $input){mappings{id}}}:{\"input\":{\"mappings\":[{\"accountKey\":\"222222222222\",\"groupUUID\":\"54880be1-9b27-453e-aecf-be743746cf4e\"}]}}": [
     {
       "request": {
         "query": "mutation ($input:UpsertAccountGroupMappingsInput!){upsertAccountGroupMappings(input: $input){mappings{id}}}",
@@ -185,7 +185,7 @@
             "mappings": [
               {
                 "accountKey": "222222222222",
-                "groupUUID": "0558c75a-393d-48ea-b2bc-e690e79219dd"
+                "groupUUID": "54880be1-9b27-453e-aecf-be743746cf4e"
               }
             ]
           }
@@ -196,7 +196,7 @@
           "upsertAccountGroupMappings": {
             "mappings": [
               {
-                "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiMDU1OGM3NWEtMzkzZC00OGVhLWIyYmMtZTY5MGU3OTIxOWRkIiwgIjIyMjIyMjIyMjIyMiJd"
+                "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiNTQ4ODBiZTEtOWIyNy00NTNlLWFlY2YtYmU3NDM3NDZjZjRlIiwgIjIyMjIyMjIyMjIyMiJd"
               }
             ]
           }
@@ -244,19 +244,19 @@
       }
     }
   ],
-  "mutation ($uuid:String!){removeAccountGroup(uuid: $uuid){group{uuid}}}:{\"uuid\":\"0558c75a-393d-48ea-b2bc-e690e79219dd\"}": [
+  "mutation ($uuid:String!){removeAccountGroup(uuid: $uuid){group{uuid}}}:{\"uuid\":\"54880be1-9b27-453e-aecf-be743746cf4e\"}": [
     {
       "request": {
         "query": "mutation ($uuid:String!){removeAccountGroup(uuid: $uuid){group{uuid}}}",
         "variables": {
-          "uuid": "0558c75a-393d-48ea-b2bc-e690e79219dd"
+          "uuid": "54880be1-9b27-453e-aecf-be743746cf4e"
         }
       },
       "response": {
         "data": {
           "removeAccountGroup": {
             "group": {
-              "uuid": "0558c75a-393d-48ea-b2bc-e690e79219dd"
+              "uuid": "54880be1-9b27-453e-aecf-be743746cf4e"
             }
           }
         }
@@ -417,26 +417,26 @@
       }
     }
   ],
-  "query ($name:String!$uuid:String!){accountGroup(uuid: $uuid, name: $name){id,uuid,name,description,provider,regions}}:{\"name\":\"\",\"uuid\":\"0558c75a-393d-48ea-b2bc-e690e79219dd\"}": [
+  "query ($name:String!$uuid:String!){accountGroup(uuid: $uuid, name: $name){id,uuid,name,description,provider,regions}}:{\"name\":\"\",\"uuid\":\"54880be1-9b27-453e-aecf-be743746cf4e\"}": [
     {
       "request": {
         "query": "query ($name:String!$uuid:String!){accountGroup(uuid: $uuid, name: $name){id,uuid,name,description,provider,regions}}",
         "variables": {
           "name": "",
-          "uuid": "0558c75a-393d-48ea-b2bc-e690e79219dd"
+          "uuid": "54880be1-9b27-453e-aecf-be743746cf4e"
         }
       },
       "response": {
         "data": {
           "accountGroup": {
             "description": "Test account group",
-            "id": "WyJhY2NvdW50LWdyb3VwIiwgIjA1NThjNzVhLTM5M2QtNDhlYS1iMmJjLWU2OTBlNzkyMTlkZCJd",
+            "id": "WyJhY2NvdW50LWdyb3VwIiwgIjU0ODgwYmUxLTliMjctNDUzZS1hZWNmLWJlNzQzNzQ2Y2Y0ZSJd",
             "name": "test-group-mappings",
             "provider": "AWS",
             "regions": [
               "us-east-1"
             ],
-            "uuid": "0558c75a-393d-48ea-b2bc-e690e79219dd"
+            "uuid": "54880be1-9b27-453e-aecf-be743746cf4e"
           }
         }
       }
@@ -446,20 +446,20 @@
         "query": "query ($name:String!$uuid:String!){accountGroup(uuid: $uuid, name: $name){id,uuid,name,description,provider,regions}}",
         "variables": {
           "name": "",
-          "uuid": "0558c75a-393d-48ea-b2bc-e690e79219dd"
+          "uuid": "54880be1-9b27-453e-aecf-be743746cf4e"
         }
       },
       "response": {
         "data": {
           "accountGroup": {
             "description": "Test account group",
-            "id": "WyJhY2NvdW50LWdyb3VwIiwgIjA1NThjNzVhLTM5M2QtNDhlYS1iMmJjLWU2OTBlNzkyMTlkZCJd",
+            "id": "WyJhY2NvdW50LWdyb3VwIiwgIjU0ODgwYmUxLTliMjctNDUzZS1hZWNmLWJlNzQzNzQ2Y2Y0ZSJd",
             "name": "test-group-mappings",
             "provider": "AWS",
             "regions": [
               "us-east-1"
             ],
-            "uuid": "0558c75a-393d-48ea-b2bc-e690e79219dd"
+            "uuid": "54880be1-9b27-453e-aecf-be743746cf4e"
           }
         }
       }
@@ -469,31 +469,31 @@
         "query": "query ($name:String!$uuid:String!){accountGroup(uuid: $uuid, name: $name){id,uuid,name,description,provider,regions}}",
         "variables": {
           "name": "",
-          "uuid": "0558c75a-393d-48ea-b2bc-e690e79219dd"
+          "uuid": "54880be1-9b27-453e-aecf-be743746cf4e"
         }
       },
       "response": {
         "data": {
           "accountGroup": {
             "description": "Test account group",
-            "id": "WyJhY2NvdW50LWdyb3VwIiwgIjA1NThjNzVhLTM5M2QtNDhlYS1iMmJjLWU2OTBlNzkyMTlkZCJd",
+            "id": "WyJhY2NvdW50LWdyb3VwIiwgIjU0ODgwYmUxLTliMjctNDUzZS1hZWNmLWJlNzQzNzQ2Y2Y0ZSJd",
             "name": "test-group-mappings",
             "provider": "AWS",
             "regions": [
               "us-east-1"
             ],
-            "uuid": "0558c75a-393d-48ea-b2bc-e690e79219dd"
+            "uuid": "54880be1-9b27-453e-aecf-be743746cf4e"
           }
         }
       }
     }
   ],
-  "query ($uuid:String!){accountGroup(uuid: $uuid){accountMappings{edges{node{id,account{key}}}}}}:{\"uuid\":\"0558c75a-393d-48ea-b2bc-e690e79219dd\"}": [
+  "query ($uuid:String!){accountGroup(uuid: $uuid){accountMappings{edges{node{id,account{key}}}}}}:{\"uuid\":\"54880be1-9b27-453e-aecf-be743746cf4e\"}": [
     {
       "request": {
         "query": "query ($uuid:String!){accountGroup(uuid: $uuid){accountMappings{edges{node{id,account{key}}}}}}",
         "variables": {
-          "uuid": "0558c75a-393d-48ea-b2bc-e690e79219dd"
+          "uuid": "54880be1-9b27-453e-aecf-be743746cf4e"
         }
       },
       "response": {
@@ -506,7 +506,7 @@
                     "account": {
                       "key": "111111111111"
                     },
-                    "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiMDU1OGM3NWEtMzkzZC00OGVhLWIyYmMtZTY5MGU3OTIxOWRkIiwgIjExMTExMTExMTExMSJd"
+                    "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiNTQ4ODBiZTEtOWIyNy00NTNlLWFlY2YtYmU3NDM3NDZjZjRlIiwgIjExMTExMTExMTExMSJd"
                   }
                 }
               ]
@@ -519,7 +519,7 @@
       "request": {
         "query": "query ($uuid:String!){accountGroup(uuid: $uuid){accountMappings{edges{node{id,account{key}}}}}}",
         "variables": {
-          "uuid": "0558c75a-393d-48ea-b2bc-e690e79219dd"
+          "uuid": "54880be1-9b27-453e-aecf-be743746cf4e"
         }
       },
       "response": {
@@ -532,7 +532,7 @@
                     "account": {
                       "key": "111111111111"
                     },
-                    "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiMDU1OGM3NWEtMzkzZC00OGVhLWIyYmMtZTY5MGU3OTIxOWRkIiwgIjExMTExMTExMTExMSJd"
+                    "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiNTQ4ODBiZTEtOWIyNy00NTNlLWFlY2YtYmU3NDM3NDZjZjRlIiwgIjExMTExMTExMTExMSJd"
                   }
                 }
               ]
@@ -545,7 +545,7 @@
       "request": {
         "query": "query ($uuid:String!){accountGroup(uuid: $uuid){accountMappings{edges{node{id,account{key}}}}}}",
         "variables": {
-          "uuid": "0558c75a-393d-48ea-b2bc-e690e79219dd"
+          "uuid": "54880be1-9b27-453e-aecf-be743746cf4e"
         }
       },
       "response": {
@@ -558,7 +558,7 @@
                     "account": {
                       "key": "111111111111"
                     },
-                    "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiMDU1OGM3NWEtMzkzZC00OGVhLWIyYmMtZTY5MGU3OTIxOWRkIiwgIjExMTExMTExMTExMSJd"
+                    "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiNTQ4ODBiZTEtOWIyNy00NTNlLWFlY2YtYmU3NDM3NDZjZjRlIiwgIjExMTExMTExMTExMSJd"
                   }
                 }
               ]
@@ -571,33 +571,7 @@
       "request": {
         "query": "query ($uuid:String!){accountGroup(uuid: $uuid){accountMappings{edges{node{id,account{key}}}}}}",
         "variables": {
-          "uuid": "0558c75a-393d-48ea-b2bc-e690e79219dd"
-        }
-      },
-      "response": {
-        "data": {
-          "accountGroup": {
-            "accountMappings": {
-              "edges": [
-                {
-                  "node": {
-                    "account": {
-                      "key": "111111111111"
-                    },
-                    "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiMDU1OGM3NWEtMzkzZC00OGVhLWIyYmMtZTY5MGU3OTIxOWRkIiwgIjExMTExMTExMTExMSJd"
-                  }
-                }
-              ]
-            }
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "query": "query ($uuid:String!){accountGroup(uuid: $uuid){accountMappings{edges{node{id,account{key}}}}}}",
-        "variables": {
-          "uuid": "0558c75a-393d-48ea-b2bc-e690e79219dd"
+          "uuid": "54880be1-9b27-453e-aecf-be743746cf4e"
         }
       },
       "response": {
@@ -610,7 +584,7 @@
                     "account": {
                       "key": "222222222222"
                     },
-                    "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiMDU1OGM3NWEtMzkzZC00OGVhLWIyYmMtZTY5MGU3OTIxOWRkIiwgIjIyMjIyMjIyMjIyMiJd"
+                    "id": "WyJhY2NvdW50LWdyb3VwLW1hcHBpbmciLCAiNTQ4ODBiZTEtOWIyNy00NTNlLWFlY2YtYmU3NDM3NDZjZjRlIiwgIjIyMjIyMjIyMjIyMiJd"
                   }
                 }
               ]

--- a/internal/helpers/error.go
+++ b/internal/helpers/error.go
@@ -5,11 +5,13 @@ import (
 	"github.com/stacklet/terraform-provider-stacklet/internal/api"
 )
 
-// AddErrors adds an error to the diagnostics.
+// AddDiagError adds an error to the diagnostics.
 func AddDiagError(diag *diag.Diagnostics, err error) {
 	switch e := err.(type) {
 	case api.APIError:
 		diag.AddError(e.Summary, e.Detail)
+	case ImportIDError:
+		diag.AddError(e.Summary(), e.Error())
 	default:
 		diag.AddError("Error", e.Error())
 	}

--- a/internal/helpers/import.go
+++ b/internal/helpers/import.go
@@ -1,0 +1,31 @@
+package helpers
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ImportIDError represent an error importing an ID.
+type ImportIDError struct {
+	parts []string
+}
+
+// Error returns the error message.
+func (e ImportIDError) Error() string {
+	format := strings.Join(e.parts, ":")
+	return fmt.Sprintf("Import ID must be in the format: %s", format)
+}
+
+// Summary returns a summary message for the error.
+func (e ImportIDError) Summary() string {
+	return "Invalid import ID"
+}
+
+// SplitImportID splits an import ID into expected components.
+func SplitImportID(id string, parts []string) ([]string, error) {
+	idParts := strings.Split(id, ":")
+	if len(idParts) != len(parts) {
+		return nil, ImportIDError{parts: parts}
+	}
+	return idParts, nil
+}

--- a/internal/resources/account.go
+++ b/internal/resources/account.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -216,21 +215,14 @@ func (r *accountResource) Delete(ctx context.Context, req resource.DeleteRequest
 }
 
 func (r *accountResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Extract the provider and key from the import ID (format: provider:key)
-	idParts := strings.Split(req.ID, ":")
-	if len(idParts) != 2 {
-		resp.Diagnostics.AddError(
-			"Invalid Import ID",
-			"Import ID must be in the format: provider:key (e.g., aws:123456789012)",
-		)
+	parts, err := helpers.SplitImportID(req.ID, []string{"provider", "key"})
+	if err != nil {
+		helpers.AddDiagError(&resp.Diagnostics, err)
 		return
 	}
 
-	provider := idParts[0]
-	key := idParts[1]
-
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("cloud_provider"), provider)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("key"), key)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("cloud_provider"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("key"), parts[1])...)
 }
 
 func updateAccountModel(m *models.AccountResource, account api.Account) {

--- a/internal/resources/account_group_mapping.go
+++ b/internal/resources/account_group_mapping.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -144,27 +143,14 @@ func (r *accountGroupMappingResource) Delete(ctx context.Context, req resource.D
 }
 
 func (r *accountGroupMappingResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	parts := strings.Split(req.ID, ":")
-	if len(parts) != 2 {
-		resp.Diagnostics.AddError(
-			"Invalid Import ID",
-			"Import ID must be in the format: $group_uuid:$account_key",
-		)
-		return
-	}
-
-	groupUUID := parts[0]
-	accountKey := parts[1]
-
-	accountGroupMapping, err := r.api.AccountGroupMapping.Read(ctx, accountKey, groupUUID)
+	parts, err := helpers.SplitImportID(req.ID, []string{"group_uuid", "account_key"})
 	if err != nil {
 		helpers.AddDiagError(&resp.Diagnostics, err)
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), accountGroupMapping.ID)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("group_uuid"), accountGroupMapping.GroupUUID)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("account_key"), accountGroupMapping.AccountKey)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("group_uuid"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("account_key"), parts[1])...)
 }
 
 func updateAccountGroupMappingModel(m *models.AccountGroupMappingResource, accountGroupMapping api.AccountGroupMapping) {

--- a/internal/resources/policy_collection_item.go
+++ b/internal/resources/policy_collection_item.go
@@ -3,13 +3,14 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hasura/go-graphql-client"
+
+	"github.com/stacklet/terraform-provider-stacklet/internal/helpers"
 )
 
 var (
@@ -216,12 +217,9 @@ type RemovePolicyCollectionMappingsInput struct {
 }
 
 func (r *policyCollectionItemResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	parts := strings.Split(req.ID, ":")
-	if len(parts) != 2 {
-		resp.Diagnostics.AddError(
-			"Invalid Import ID",
-			"Import ID must be in the format: collection_uuid:policy_uuid",
-		)
+	parts, err := helpers.SplitImportID(req.ID, []string{"collection_uuid", "policy_uuid"})
+	if err != nil {
+		helpers.AddDiagError(&resp.Diagnostics, err)
 		return
 	}
 


### PR DESCRIPTION
### what

add `SplitImportId` helper to handle splitting an import ID into expected
parts.

### why

Factor out common logic across resources.

### testing

unit tests

### docs

n/a
