### PR TITLE
chore: drop unneeded api.Nullable* helpers

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -45,26 +45,6 @@ func (cp CloudProvider) String() string {
 	return string(cp)
 }
 
-// NullableString converts a types.String to a string pointer which can be null.
-func NullableString(s types.String) *string {
-	if s.IsNull() {
-		return nil
-	}
-
-	str := s.ValueString()
-	return &str
-}
-
-// NullableBool converts a types.Bool to a bool pointer which can be null.
-func NullableBool(b types.Bool) *bool {
-	if b.IsNull() {
-		return nil
-	}
-
-	bv := b.ValueBool()
-	return &bv
-}
-
 // StringsList concerts a types.List to a list of strings.
 func StringsList(l types.List) []string {
 	if l.IsNull() || l.IsUnknown() {

--- a/internal/resources/account.go
+++ b/internal/resources/account.go
@@ -118,11 +118,11 @@ func (r *accountResource) Create(ctx context.Context, req resource.CreateRequest
 		Name:            plan.Name.ValueString(),
 		Key:             plan.Key.ValueString(),
 		Provider:        api.CloudProvider(plan.CloudProvider.ValueString()),
-		ShortName:       api.NullableString(plan.ShortName),
-		Description:     api.NullableString(plan.Description),
-		Email:           api.NullableString(plan.Email),
-		SecurityContext: api.NullableString(plan.SecurityContext),
-		Variables:       api.NullableString(plan.Variables),
+		ShortName:       plan.ShortName.ValueStringPointer(),
+		Description:     plan.Description.ValueStringPointer(),
+		Email:           plan.Email.ValueStringPointer(),
+		SecurityContext: plan.SecurityContext.ValueStringPointer(),
+		Variables:       plan.Variables.ValueStringPointer(),
 	}
 	account, err := r.api.Account.Create(ctx, input)
 	if err != nil {
@@ -166,12 +166,12 @@ func (r *accountResource) Update(ctx context.Context, req resource.UpdateRequest
 	input := api.AccountUpdateInput{
 		Key:             plan.Key.ValueString(),
 		Provider:        api.CloudProvider(plan.CloudProvider.ValueString()),
-		Name:            api.NullableString(plan.Name),
-		ShortName:       api.NullableString(plan.ShortName),
-		Description:     api.NullableString(plan.Description),
-		Email:           api.NullableString(plan.Email),
-		SecurityContext: api.NullableString(plan.SecurityContext),
-		Variables:       api.NullableString(plan.Variables),
+		Name:            plan.Name.ValueStringPointer(),
+		ShortName:       plan.ShortName.ValueStringPointer(),
+		Description:     plan.Description.ValueStringPointer(),
+		Email:           plan.Email.ValueStringPointer(),
+		SecurityContext: plan.SecurityContext.ValueStringPointer(),
+		Variables:       plan.Variables.ValueStringPointer(),
 	}
 
 	account, err := r.api.Account.Update(ctx, input)

--- a/internal/resources/account_group.go
+++ b/internal/resources/account_group.go
@@ -97,7 +97,7 @@ func (r *accountGroupResource) Create(ctx context.Context, req resource.CreateRe
 	input := api.AccountGroupCreateInput{
 		Name:        plan.Name.ValueString(),
 		Provider:    plan.CloudProvider.ValueString(),
-		Description: api.NullableString(plan.Description),
+		Description: plan.Description.ValueStringPointer(),
 		Regions:     api.StringsList(plan.Regions),
 	}
 
@@ -141,8 +141,8 @@ func (r *accountGroupResource) Update(ctx context.Context, req resource.UpdateRe
 
 	input := api.AccountGroupUpdateInput{
 		UUID:        plan.UUID.ValueString(),
-		Name:        api.NullableString(plan.Name),
-		Description: api.NullableString(plan.Description),
+		Name:        plan.Name.ValueStringPointer(),
+		Description: plan.Description.ValueStringPointer(),
 		Regions:     api.StringsList(plan.Regions),
 	}
 

--- a/internal/resources/binding.go
+++ b/internal/resources/binding.go
@@ -116,11 +116,11 @@ func (r *bindingResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 	input := api.BindingCreateInput{
 		Name:        plan.Name.ValueString(),
-		Description: api.NullableString(plan.Description),
+		Description: plan.Description.ValueStringPointer(),
 		AutoDeploy:  plan.AutoDeploy.ValueBool(),
-		Schedule:    api.NullableString(plan.Schedule),
+		Schedule:    plan.Schedule.ValueStringPointer(),
 		ExecutionConfig: api.BindingExecutionConfig{
-			Variables: api.NullableString(plan.Variables),
+			Variables: plan.Variables.ValueStringPointer(),
 		},
 		AccountGroupUUID:     plan.AccountGroupUUID.ValueString(),
 		PolicyCollectionUUID: plan.PolicyCollectionUUID.ValueString(),
@@ -175,11 +175,11 @@ func (r *bindingResource) Update(ctx context.Context, req resource.UpdateRequest
 	input := api.BindingUpdateInput{
 		UUID:        plan.UUID.ValueString(),
 		Name:        plan.Name.ValueString(),
-		Description: api.NullableString(plan.Description),
+		Description: plan.Description.ValueStringPointer(),
 		AutoDeploy:  plan.AutoDeploy.ValueBool(),
-		Schedule:    api.NullableString(plan.Schedule),
+		Schedule:    plan.Schedule.ValueStringPointer(),
 		ExecutionConfig: api.BindingExecutionConfig{
-			Variables: api.NullableString(plan.Variables),
+			Variables: plan.Variables.ValueStringPointer(),
 		},
 	}
 

--- a/internal/resources/policy_collection.go
+++ b/internal/resources/policy_collection.go
@@ -122,7 +122,7 @@ func (r *policyCollectionResource) Create(ctx context.Context, req resource.Crea
 	input := api.PolicyCollectionCreateInput{
 		Name:        plan.Name.ValueString(),
 		Provider:    api.CloudProvider(plan.CloudProvider.ValueString()),
-		Description: api.NullableString(plan.Description),
+		Description: plan.Description.ValueStringPointer(),
 		AutoUpdate:  plan.AutoUpdate.ValueBoolPointer(),
 	}
 	policyCollection, err := r.api.PolicyCollection.Create(ctx, input)

--- a/internal/resources/repository.go
+++ b/internal/resources/repository.go
@@ -161,14 +161,14 @@ func (r *RepositoryResource) Create(ctx context.Context, req resource.CreateRequ
 
 	// Create remote from plan and config.
 	auth := api.NewRepositoryConfigAuthInput()
-	auth.SetAuthUser(api.NullableString(plan.AuthUser))
-	auth.SetAuthToken(api.NullableString(config.AuthTokenWO))
-	auth.SetSSHPrivateKey(api.NullableString(config.SSHPrivateKeyWO))
-	auth.SetSSHPassphrase(api.NullableString(config.SSHPassphraseWO))
+	auth.SetAuthUser(plan.AuthUser.ValueStringPointer())
+	auth.SetAuthToken(config.AuthTokenWO.ValueStringPointer())
+	auth.SetSSHPrivateKey(config.SSHPrivateKeyWO.ValueStringPointer())
+	auth.SetSSHPassphrase(config.SSHPassphraseWO.ValueStringPointer())
 	input := api.RepositoryCreateInput{
 		Name:        plan.Name.ValueString(),
 		URL:         plan.URL.ValueString(),
-		Description: api.NullableString(plan.Description),
+		Description: plan.Description.ValueStringPointer(),
 		Auth:        auth,
 	}
 	repo, err := r.api.Repository.Create(ctx, input)
@@ -218,25 +218,25 @@ func (r *RepositoryResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	// Determine which auth fields need to be updated.
 	auth := api.NewRepositoryConfigAuthInput()
-	auth.SetAuthUser(api.NullableString(plan.AuthUser))
+	auth.SetAuthUser(plan.AuthUser.ValueStringPointer())
 	if state.AuthTokenWOVersion != plan.AuthTokenWOVersion {
 		state.AuthTokenWOVersion = plan.AuthTokenWOVersion
-		auth.SetAuthToken(api.NullableString(config.AuthTokenWO))
+		auth.SetAuthToken(config.AuthTokenWO.ValueStringPointer())
 	}
 	if state.SSHPrivateKeyWOVersion != plan.SSHPrivateKeyWOVersion {
 		state.SSHPrivateKeyWOVersion = plan.SSHPrivateKeyWOVersion
-		auth.SetSSHPrivateKey(api.NullableString(config.SSHPrivateKeyWO))
+		auth.SetSSHPrivateKey(config.SSHPrivateKeyWO.ValueStringPointer())
 	}
 	if state.SSHPassphraseWOVersion != plan.SSHPassphraseWOVersion {
 		state.SSHPassphraseWOVersion = plan.SSHPassphraseWOVersion
-		auth.SetSSHPassphrase(api.NullableString(config.SSHPassphraseWO))
+		auth.SetSSHPassphrase(config.SSHPassphraseWO.ValueStringPointer())
 	}
 
 	// Update remote according to the combined grand plan.
 	input := api.RepositoryUpdateInput{
 		UUID:        plan.UUID.ValueString(),
 		Name:        plan.Name.ValueString(),
-		Description: api.NullableString(plan.Description),
+		Description: plan.Description.ValueStringPointer(),
 		Auth:        auth,
 	}
 	repo, err := r.api.Repository.Update(ctx, input)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -16,14 +16,6 @@ func NullableString(s *string) types.String {
 	return types.StringValue(*s)
 }
 
-// NullableBool returns the proper type for a nullable boolean.
-func NullableBool(b *bool) types.Bool {
-	if b == nil {
-		return types.BoolNull()
-	}
-	return types.BoolValue(*b)
-}
-
 // StringsList returns a list of values of string type.
 func StringsList(l []string) basetypes.ListValue {
 	sl := make([]attr.Value, len(l))


### PR DESCRIPTION
### what

- drop api.NullableString since types.String.ValueStringPointer() has the same
logic
- drop unused api.NullableBool types.NullableBool

### why

remove unneded code

### testing

unit tests

### docs

n/a
