### PR TITLE
feat: handle account security context as a WO secret [ENG-5163]

### DIFF
--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -15,13 +15,13 @@ Manage a Stacklet account with a specific cloud provider.
 ```terraform
 # Configure an AWS account
 resource "stacklet_account" "aws_prod" {
-  cloud_provider   = "AWS"
-  key              = "123456789012" # AWS account ID
-  name             = "Production AWS Account"
-  description      = "Main production AWS account"
-  email            = "cloud-team@example.com"
-  security_context = "arn:aws:iam::123456789012:role/stacklet-execution"
-
+  cloud_provider              = "AWS"
+  key                         = "123456789012" # AWS account ID
+  name                        = "Production AWS Account"
+  description                 = "Main production AWS account"
+  email                       = "cloud-team@example.com"
+  security_context_wo         = "arn:aws:iam::123456789012:role/stacklet-execution"
+  security_context_wo_version = "1"
   variables = jsonencode({
     environment = "production"
     team        = "platform"
@@ -35,29 +35,32 @@ resource "stacklet_account" "azure_dev" {
   key            = "00000000-0000-0000-0000-000000000000" # Azure subscription ID
   name           = "Development Azure Subscription"
   description    = "Development environment in Azure"
-  security_context = jsonencode({
+  security_context_wo = jsonencode({
     tenant_id     = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
     client_id     = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
     client_secret = "seKret"
   })
+  security_context_wo_version = "1"
 }
 
 # Configure a GCP project
 resource "stacklet_account" "gcp_staging" {
-  cloud_provider   = "GCP"
-  key              = "my-project-id" # GCP project ID
-  name             = "Staging GCP Project"
-  description      = "Staging environment in GCP"
-  security_context = "arn:aws:secretsmanager:us-east-11:12345678912:secret:gcp-staging" # ARN of the secret containing the configuration
+  cloud_provider              = "GCP"
+  key                         = "my-project-id" # GCP project ID
+  name                        = "Staging GCP Project"
+  description                 = "Staging environment in GCP"
+  security_context_wo         = "arn:aws:secretsmanager:us-east-11:12345678912:secret:gcp-staging" # ARN of the secret containing the configuration
+  security_context_wo_version = "1"
 }
 
 # Configure a Tencent Cloud account
 resource "stacklet_account" "tencent_prod" {
-  cloud_provider   = "TencentCloud"
-  key              = "1234567890" # Tencent Cloud account ID
-  name             = "Production Tencent Cloud Account"
-  description      = "Production environment in Tencent Cloud"
-  security_context = "arn:aws:secretsmanager:us-east-11:12345678912:secret:tencent-prod" # ARN of the secret containing the configuration
+  cloud_provider              = "TencentCloud"
+  key                         = "1234567890" # Tencent Cloud account ID
+  name                        = "Production Tencent Cloud Account"
+  description                 = "Production environment in Tencent Cloud"
+  security_context_wo         = "arn:aws:secretsmanager:us-east-11:12345678912:secret:tencent-prod" # ARN of the secret containing the configuration
+  security_context_wo_version = "1"
 }
 ```
 
@@ -72,16 +75,20 @@ resource "stacklet_account" "tencent_prod" {
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `description` (String) More detailed information about the account.
 - `email` (String) The email contact address for the account.
 - `path` (String) The path used to group accounts in a hierarchy.
-- `security_context` (String, Sensitive) The security context for the account.
+- `security_context_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The input value for the security context for the account.
+- `security_context_wo_version` (String) The version for the security context. Must be changed to update security_context_wo.
 - `short_name` (String) The short name for the account.
 - `variables` (String) JSON encoded dict of values used for policy templating.
 
 ### Read-Only
 
 - `id` (String) The GraphQL Node ID of the account.
+- `security_context` (String) The security context for the account, as returned by the API.
 
 ## Import
 

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -25,7 +25,7 @@ resource "stacklet_repository" "example_http_auth" {
 
   auth_user             = "some-user"
   auth_token_wo         = "ghp_xxxxxxxxxxxxxxxxxxxx"
-  auth_token_wo_version = 1
+  auth_token_wo_version = "1"
 }
 
 resource "stacklet_repository" "example_ssh_auth" {
@@ -41,7 +41,7 @@ AAAEC/dsi/DISHYy8HxIrX5JWLWhYKv2XFBlL15NLRzIlA5tBIt1S68mWzaTbxsvJqUsKt
 ktoEb85tBcGQQmXy8HUbAAAADnJlcG8tdGVzdC1yYXcKAQIDBAUGBw==
 -----END OPENSSH PRIVATE KEY-----
 EOT
-  ssh_private_key_wo_version = 1
+  ssh_private_key_wo_version = "1"
 }
 
 resource "stacklet_repository" "example_codecommit" {
@@ -49,7 +49,7 @@ resource "stacklet_repository" "example_codecommit" {
   url  = "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/example"
 
   auth_token_wo         = "arn:aws:iam::123456789012:role/example-repo-access"
-  auth_token_wo_version = 1
+  auth_token_wo_version = "1"
 }
 ```
 

--- a/examples/resources/stacklet_account/resource.tf
+++ b/examples/resources/stacklet_account/resource.tf
@@ -1,12 +1,12 @@
 # Configure an AWS account
 resource "stacklet_account" "aws_prod" {
-  cloud_provider   = "AWS"
-  key              = "123456789012" # AWS account ID
-  name             = "Production AWS Account"
-  description      = "Main production AWS account"
-  email            = "cloud-team@example.com"
-  security_context = "arn:aws:iam::123456789012:role/stacklet-execution"
-
+  cloud_provider              = "AWS"
+  key                         = "123456789012" # AWS account ID
+  name                        = "Production AWS Account"
+  description                 = "Main production AWS account"
+  email                       = "cloud-team@example.com"
+  security_context_wo         = "arn:aws:iam::123456789012:role/stacklet-execution"
+  security_context_wo_version = "1"
   variables = jsonencode({
     environment = "production"
     team        = "platform"
@@ -20,27 +20,30 @@ resource "stacklet_account" "azure_dev" {
   key            = "00000000-0000-0000-0000-000000000000" # Azure subscription ID
   name           = "Development Azure Subscription"
   description    = "Development environment in Azure"
-  security_context = jsonencode({
+  security_context_wo = jsonencode({
     tenant_id     = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
     client_id     = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
     client_secret = "seKret"
   })
+  security_context_wo_version = "1"
 }
 
 # Configure a GCP project
 resource "stacklet_account" "gcp_staging" {
-  cloud_provider   = "GCP"
-  key              = "my-project-id" # GCP project ID
-  name             = "Staging GCP Project"
-  description      = "Staging environment in GCP"
-  security_context = "arn:aws:secretsmanager:us-east-11:12345678912:secret:gcp-staging" # ARN of the secret containing the configuration
+  cloud_provider              = "GCP"
+  key                         = "my-project-id" # GCP project ID
+  name                        = "Staging GCP Project"
+  description                 = "Staging environment in GCP"
+  security_context_wo         = "arn:aws:secretsmanager:us-east-11:12345678912:secret:gcp-staging" # ARN of the secret containing the configuration
+  security_context_wo_version = "1"
 }
 
 # Configure a Tencent Cloud account
 resource "stacklet_account" "tencent_prod" {
-  cloud_provider   = "TencentCloud"
-  key              = "1234567890" # Tencent Cloud account ID
-  name             = "Production Tencent Cloud Account"
-  description      = "Production environment in Tencent Cloud"
-  security_context = "arn:aws:secretsmanager:us-east-11:12345678912:secret:tencent-prod" # ARN of the secret containing the configuration
+  cloud_provider              = "TencentCloud"
+  key                         = "1234567890" # Tencent Cloud account ID
+  name                        = "Production Tencent Cloud Account"
+  description                 = "Production environment in Tencent Cloud"
+  security_context_wo         = "arn:aws:secretsmanager:us-east-11:12345678912:secret:tencent-prod" # ARN of the secret containing the configuration
+  security_context_wo_version = "1"
 }

--- a/examples/resources/stacklet_repository/resource.tf
+++ b/examples/resources/stacklet_repository/resource.tf
@@ -10,7 +10,7 @@ resource "stacklet_repository" "example_http_auth" {
 
   auth_user             = "some-user"
   auth_token_wo         = "ghp_xxxxxxxxxxxxxxxxxxxx"
-  auth_token_wo_version = 1
+  auth_token_wo_version = "1"
 }
 
 resource "stacklet_repository" "example_ssh_auth" {
@@ -26,7 +26,7 @@ AAAEC/dsi/DISHYy8HxIrX5JWLWhYKv2XFBlL15NLRzIlA5tBIt1S68mWzaTbxsvJqUsKt
 ktoEb85tBcGQQmXy8HUbAAAADnJlcG8tdGVzdC1yYXcKAQIDBAUGBw==
 -----END OPENSSH PRIVATE KEY-----
 EOT
-  ssh_private_key_wo_version = 1
+  ssh_private_key_wo_version = "1"
 }
 
 resource "stacklet_repository" "example_codecommit" {
@@ -34,5 +34,5 @@ resource "stacklet_repository" "example_codecommit" {
   url  = "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/example"
 
   auth_token_wo         = "arn:aws:iam::123456789012:role/example-repo-access"
-  auth_token_wo_version = 1
+  auth_token_wo_version = "1"
 }

--- a/internal/acceptance_tests/account_data_source_test.go
+++ b/internal/acceptance_tests/account_data_source_test.go
@@ -18,7 +18,9 @@ func TestAccAccountDataSource(t *testing.T) {
 						description = "Test AWS account"
 						short_name = "test"
 						email = "test@example.com"
-						variables = "{\"environment\": \"test\"}"
+						variables = jsonencode({
+                            environment = "test"
+                        })
 					}
 				`,
 		},
@@ -32,7 +34,9 @@ func TestAccAccountDataSource(t *testing.T) {
 						description = "Test AWS account"
 						short_name = "test"
 						email = "test@example.com"
-						variables = "{\"environment\": \"test\"}"
+						variables = jsonencode({
+                            environment = "test"
+                        })
 					}
 
 					data "stacklet_account" "test" {
@@ -47,7 +51,7 @@ func TestAccAccountDataSource(t *testing.T) {
 				resource.TestCheckResourceAttr("data.stacklet_account.test", "description", "Test AWS account"),
 				resource.TestCheckResourceAttr("data.stacklet_account.test", "short_name", "test"),
 				resource.TestCheckResourceAttr("data.stacklet_account.test", "email", "test@example.com"),
-				resource.TestCheckResourceAttr("data.stacklet_account.test", "variables", "{\"environment\": \"test\"}"),
+				resource.TestCheckResourceAttr("data.stacklet_account.test", "variables", "{\"environment\":\"test\"}"),
 				resource.TestCheckResourceAttrSet("data.stacklet_account.test", "id"),
 			),
 		},

--- a/internal/acceptance_tests/account_resource_test.go
+++ b/internal/acceptance_tests/account_resource_test.go
@@ -18,7 +18,11 @@ func TestAccAccountResource(t *testing.T) {
 						description = "Test AWS account"
 						short_name = "test"
 						email = "test@example.com"
-						variables = "{\"environment\": \"test\"}"
+						variables = jsonencode({
+                            environment = "test"
+                        })
+                        security_context_wo = "arn:aws:iam::123456789012:role/stacklet-execution"
+                        security_context_wo_version = "1"
 					}
 				`,
 			Check: resource.ComposeAggregateTestCheckFunc(
@@ -28,7 +32,9 @@ func TestAccAccountResource(t *testing.T) {
 				resource.TestCheckResourceAttr("stacklet_account.test", "description", "Test AWS account"),
 				resource.TestCheckResourceAttr("stacklet_account.test", "short_name", "test"),
 				resource.TestCheckResourceAttr("stacklet_account.test", "email", "test@example.com"),
-				resource.TestCheckResourceAttr("stacklet_account.test", "variables", "{\"environment\": \"test\"}"),
+				resource.TestCheckResourceAttr("stacklet_account.test", "variables", "{\"environment\":\"test\"}"),
+				// For AWS, passing a role ARN as security_context_wo passes it through as a security_context
+				resource.TestCheckResourceAttr("stacklet_account.test", "security_context", "arn:aws:iam::123456789012:role/stacklet-execution"),
 				resource.TestCheckResourceAttrSet("stacklet_account.test", "id"),
 			),
 		},
@@ -50,7 +56,11 @@ func TestAccAccountResource(t *testing.T) {
 						description = "Updated AWS account"
 						short_name = "test-updated"
 						email = "updated@example.com"
-						variables = "{\"environment\": \"staging\"}"
+						variables = jsonencode({
+                            environment = "staging"
+                        })
+                        security_context_wo = "arn:aws:iam::123456789012:role/stacklet-execution-new"
+                        security_context_wo_version = "2"
 					}
 				`,
 			Check: resource.ComposeAggregateTestCheckFunc(
@@ -60,7 +70,8 @@ func TestAccAccountResource(t *testing.T) {
 				resource.TestCheckResourceAttr("stacklet_account.test", "description", "Updated AWS account"),
 				resource.TestCheckResourceAttr("stacklet_account.test", "short_name", "test-updated"),
 				resource.TestCheckResourceAttr("stacklet_account.test", "email", "updated@example.com"),
-				resource.TestCheckResourceAttr("stacklet_account.test", "variables", "{\"environment\": \"staging\"}"),
+				resource.TestCheckResourceAttr("stacklet_account.test", "variables", "{\"environment\":\"staging\"}"),
+				resource.TestCheckResourceAttr("stacklet_account.test", "security_context", "arn:aws:iam::123456789012:role/stacklet-execution-new"),
 			),
 		},
 	}

--- a/internal/acceptance_tests/recordings/TestAccAccountDataSource.json
+++ b/internal/acceptance_tests/recordings/TestAccAccountDataSource.json
@@ -1,8 +1,8 @@
 {
-  "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,variables}}}:{\"input\":{\"description\":\"Test AWS account\",\"email\":\"test@example.com\",\"key\":\"999999999999\",\"name\":\"test-account-ds\",\"provider\":\"AWS\",\"shortName\":\"test\",\"variables\":\"{\\\"environment\\\": \\\"test\\\"}\"}}": [
+  "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}}:{\"input\":{\"description\":\"Test AWS account\",\"email\":\"test@example.com\",\"key\":\"999999999999\",\"name\":\"test-account-ds\",\"provider\":\"AWS\",\"shortName\":\"test\",\"variables\":\"{\\\"environment\\\":\\\"test\\\"}\"}}": [
     {
       "request": {
-        "query": "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,variables}}}",
+        "query": "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}}",
         "variables": {
           "input": {
             "description": "Test AWS account",
@@ -11,7 +11,7 @@
             "name": "test-account-ds",
             "provider": "AWS",
             "shortName": "test",
-            "variables": "{\"environment\": \"test\"}"
+            "variables": "{\"environment\":\"test\"}"
           }
         }
       },
@@ -27,8 +27,9 @@
               "name": "test-account-ds",
               "path": null,
               "provider": "AWS",
+              "securityContext": "",
               "shortName": "test",
-              "variables": "{\"environment\": \"test\"}"
+              "variables": "{\"environment\":\"test\"}"
             }
           }
         }
@@ -55,10 +56,10 @@
       }
     }
   ],
-  "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}:{\"key\":\"999999999999\",\"provider\":\"AWS\"}": [
+  "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}:{\"key\":\"999999999999\",\"provider\":\"AWS\"}": [
     {
       "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
         "variables": {
           "key": "999999999999",
           "provider": "AWS"
@@ -75,15 +76,16 @@
             "name": "test-account-ds",
             "path": null,
             "provider": "AWS",
+            "securityContext": "",
             "shortName": "test",
-            "variables": "{\"environment\": \"test\"}"
+            "variables": "{\"environment\":\"test\"}"
           }
         }
       }
     },
     {
       "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
         "variables": {
           "key": "999999999999",
           "provider": "AWS"
@@ -100,15 +102,16 @@
             "name": "test-account-ds",
             "path": null,
             "provider": "AWS",
+            "securityContext": "",
             "shortName": "test",
-            "variables": "{\"environment\": \"test\"}"
+            "variables": "{\"environment\":\"test\"}"
           }
         }
       }
     },
     {
       "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
         "variables": {
           "key": "999999999999",
           "provider": "AWS"
@@ -125,15 +128,16 @@
             "name": "test-account-ds",
             "path": null,
             "provider": "AWS",
+            "securityContext": "",
             "shortName": "test",
-            "variables": "{\"environment\": \"test\"}"
+            "variables": "{\"environment\":\"test\"}"
           }
         }
       }
     },
     {
       "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
         "variables": {
           "key": "999999999999",
           "provider": "AWS"
@@ -150,15 +154,16 @@
             "name": "test-account-ds",
             "path": null,
             "provider": "AWS",
+            "securityContext": "",
             "shortName": "test",
-            "variables": "{\"environment\": \"test\"}"
+            "variables": "{\"environment\":\"test\"}"
           }
         }
       }
     },
     {
       "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
         "variables": {
           "key": "999999999999",
           "provider": "AWS"
@@ -175,15 +180,16 @@
             "name": "test-account-ds",
             "path": null,
             "provider": "AWS",
+            "securityContext": "",
             "shortName": "test",
-            "variables": "{\"environment\": \"test\"}"
+            "variables": "{\"environment\":\"test\"}"
           }
         }
       }
     },
     {
       "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
         "variables": {
           "key": "999999999999",
           "provider": "AWS"
@@ -200,8 +206,9 @@
             "name": "test-account-ds",
             "path": null,
             "provider": "AWS",
+            "securityContext": "",
             "shortName": "test",
-            "variables": "{\"environment\": \"test\"}"
+            "variables": "{\"environment\":\"test\"}"
           }
         }
       }

--- a/internal/acceptance_tests/recordings/TestAccAccountGroupMappingResource.json
+++ b/internal/acceptance_tests/recordings/TestAccAccountGroupMappingResource.json
@@ -1,8 +1,8 @@
 {
-  "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,variables}}}:{\"input\":{\"description\":\"Test AWS account 1\",\"key\":\"111111111111\",\"name\":\"test-account-1\",\"provider\":\"AWS\"}}": [
+  "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}}:{\"input\":{\"description\":\"Test AWS account 1\",\"key\":\"111111111111\",\"name\":\"test-account-1\",\"provider\":\"AWS\"}}": [
     {
       "request": {
-        "query": "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,variables}}}",
+        "query": "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}}",
         "variables": {
           "input": {
             "description": "Test AWS account 1",
@@ -24,6 +24,7 @@
               "name": "test-account-1",
               "path": null,
               "provider": "AWS",
+              "securityContext": "",
               "shortName": null,
               "variables": null
             }
@@ -32,10 +33,10 @@
       }
     }
   ],
-  "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,variables}}}:{\"input\":{\"description\":\"Test AWS account 2\",\"key\":\"222222222222\",\"name\":\"test-account-2\",\"provider\":\"AWS\"}}": [
+  "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}}:{\"input\":{\"description\":\"Test AWS account 2\",\"key\":\"222222222222\",\"name\":\"test-account-2\",\"provider\":\"AWS\"}}": [
     {
       "request": {
-        "query": "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,variables}}}",
+        "query": "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}}",
         "variables": {
           "input": {
             "description": "Test AWS account 2",
@@ -57,6 +58,7 @@
               "name": "test-account-2",
               "path": null,
               "provider": "AWS",
+              "securityContext": "",
               "shortName": null,
               "variables": null
             }
@@ -399,10 +401,10 @@
       }
     }
   ],
-  "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}:{\"key\":\"111111111111\",\"provider\":\"AWS\"}": [
+  "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}:{\"key\":\"111111111111\",\"provider\":\"AWS\"}": [
     {
       "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
         "variables": {
           "key": "111111111111",
           "provider": "AWS"
@@ -419,6 +421,7 @@
             "name": "test-account-1",
             "path": null,
             "provider": "AWS",
+            "securityContext": "",
             "shortName": null,
             "variables": null
           }
@@ -427,7 +430,7 @@
     },
     {
       "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
         "variables": {
           "key": "111111111111",
           "provider": "AWS"
@@ -444,6 +447,7 @@
             "name": "test-account-1",
             "path": null,
             "provider": "AWS",
+            "securityContext": "",
             "shortName": null,
             "variables": null
           }
@@ -452,7 +456,7 @@
     },
     {
       "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
         "variables": {
           "key": "111111111111",
           "provider": "AWS"
@@ -469,6 +473,7 @@
             "name": "test-account-1",
             "path": null,
             "provider": "AWS",
+            "securityContext": "",
             "shortName": null,
             "variables": null
           }
@@ -476,10 +481,10 @@
       }
     }
   ],
-  "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}:{\"key\":\"222222222222\",\"provider\":\"AWS\"}": [
+  "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}:{\"key\":\"222222222222\",\"provider\":\"AWS\"}": [
     {
       "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
         "variables": {
           "key": "222222222222",
           "provider": "AWS"
@@ -496,6 +501,7 @@
             "name": "test-account-2",
             "path": null,
             "provider": "AWS",
+            "securityContext": "",
             "shortName": null,
             "variables": null
           }
@@ -504,7 +510,7 @@
     },
     {
       "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
         "variables": {
           "key": "222222222222",
           "provider": "AWS"
@@ -521,6 +527,7 @@
             "name": "test-account-2",
             "path": null,
             "provider": "AWS",
+            "securityContext": "",
             "shortName": null,
             "variables": null
           }
@@ -529,7 +536,7 @@
     },
     {
       "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
         "variables": {
           "key": "222222222222",
           "provider": "AWS"
@@ -546,6 +553,7 @@
             "name": "test-account-2",
             "path": null,
             "provider": "AWS",
+            "securityContext": "",
             "shortName": null,
             "variables": null
           }

--- a/internal/acceptance_tests/recordings/TestAccAccountResource.json
+++ b/internal/acceptance_tests/recordings/TestAccAccountResource.json
@@ -1,8 +1,8 @@
 {
-  "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,variables}}}:{\"input\":{\"description\":\"Test AWS account\",\"email\":\"test@example.com\",\"key\":\"999999999999\",\"name\":\"test-account\",\"provider\":\"AWS\",\"shortName\":\"test\",\"variables\":\"{\\\"environment\\\": \\\"test\\\"}\"}}": [
+  "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}}:{\"input\":{\"description\":\"Test AWS account\",\"email\":\"test@example.com\",\"key\":\"999999999999\",\"name\":\"test-account\",\"provider\":\"AWS\",\"securityContext\":\"arn:aws:iam::123456789012:role/stacklet-execution\",\"shortName\":\"test\",\"variables\":\"{\\\"environment\\\":\\\"test\\\"}\"}}": [
     {
       "request": {
-        "query": "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,variables}}}",
+        "query": "mutation ($input:AccountInput!){addAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}}",
         "variables": {
           "input": {
             "description": "Test AWS account",
@@ -10,8 +10,9 @@
             "key": "999999999999",
             "name": "test-account",
             "provider": "AWS",
+            "securityContext": "arn:aws:iam::123456789012:role/stacklet-execution",
             "shortName": "test",
-            "variables": "{\"environment\": \"test\"}"
+            "variables": "{\"environment\":\"test\"}"
           }
         }
       },
@@ -27,120 +28,19 @@
               "name": "test-account",
               "path": null,
               "provider": "AWS",
+              "securityContext": "arn:aws:iam::123456789012:role/stacklet-execution",
               "shortName": "test",
-              "variables": "{\"environment\": \"test\"}"
+              "variables": "{\"environment\":\"test\"}"
             }
           }
         }
       }
     }
   ],
-  "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}:{\"key\":\"999999999999\",\"provider\":\"AWS\"}": [
+  "mutation ($input:UpdateAccountInput!){updateAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}}:{\"input\":{\"description\":\"Updated AWS account\",\"email\":\"updated@example.com\",\"key\":\"999999999999\",\"name\":\"test-account-updated\",\"provider\":\"AWS\",\"securityContext\":\"arn:aws:iam::123456789012:role/stacklet-execution-new\",\"shortName\":\"test-updated\",\"variables\":\"{\\\"environment\\\":\\\"staging\\\"}\"}}": [
     {
       "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
-        "variables": {
-          "key": "999999999999",
-          "provider": "AWS"
-        }
-      },
-      "response": {
-        "data": {
-          "account": {
-            "active": true,
-            "description": "Test AWS account",
-            "email": "test@example.com",
-            "id": "WyJhY2NvdW50IiwgImF3cyIsICI5OTk5OTk5OTk5OTkiXQ==",
-            "key": "999999999999",
-            "name": "test-account",
-            "path": null,
-            "provider": "AWS",
-            "shortName": "test",
-            "variables": "{\"environment\": \"test\"}"
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
-        "variables": {
-          "key": "999999999999",
-          "provider": "AWS"
-        }
-      },
-      "response": {
-        "data": {
-          "account": {
-            "active": true,
-            "description": "Test AWS account",
-            "email": "test@example.com",
-            "id": "WyJhY2NvdW50IiwgImF3cyIsICI5OTk5OTk5OTk5OTkiXQ==",
-            "key": "999999999999",
-            "name": "test-account",
-            "path": null,
-            "provider": "AWS",
-            "shortName": "test",
-            "variables": "{\"environment\": \"test\"}"
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
-        "variables": {
-          "key": "999999999999",
-          "provider": "AWS"
-        }
-      },
-      "response": {
-        "data": {
-          "account": {
-            "active": true,
-            "description": "Test AWS account",
-            "email": "test@example.com",
-            "id": "WyJhY2NvdW50IiwgImF3cyIsICI5OTk5OTk5OTk5OTkiXQ==",
-            "key": "999999999999",
-            "name": "test-account",
-            "path": null,
-            "provider": "AWS",
-            "shortName": "test",
-            "variables": "{\"environment\": \"test\"}"
-          }
-        }
-      }
-    },
-    {
-      "request": {
-        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,variables}}",
-        "variables": {
-          "key": "999999999999",
-          "provider": "AWS"
-        }
-      },
-      "response": {
-        "data": {
-          "account": {
-            "active": true,
-            "description": "Updated AWS account",
-            "email": "updated@example.com",
-            "id": "WyJhY2NvdW50IiwgImF3cyIsICI5OTk5OTk5OTk5OTkiXQ==",
-            "key": "999999999999",
-            "name": "test-account-updated",
-            "path": null,
-            "provider": "AWS",
-            "shortName": "test-updated",
-            "variables": "{\"environment\": \"staging\"}"
-          }
-        }
-      }
-    }
-  ],
-  "mutation ($input:UpdateAccountInput!){updateAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,variables}}}:{\"input\":{\"description\":\"Updated AWS account\",\"email\":\"updated@example.com\",\"key\":\"999999999999\",\"name\":\"test-account-updated\",\"provider\":\"AWS\",\"securityContext\":null,\"shortName\":\"test-updated\",\"variables\":\"{\\\"environment\\\": \\\"staging\\\"}\"}}": [
-    {
-      "request": {
-        "query": "mutation ($input:UpdateAccountInput!){updateAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,variables}}}",
+        "query": "mutation ($input:UpdateAccountInput!){updateAccount(input: $input){account{id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}}",
         "variables": {
           "input": {
             "description": "Updated AWS account",
@@ -148,9 +48,9 @@
             "key": "999999999999",
             "name": "test-account-updated",
             "provider": "AWS",
-            "securityContext": null,
+            "securityContext": "arn:aws:iam::123456789012:role/stacklet-execution-new",
             "shortName": "test-updated",
-            "variables": "{\"environment\": \"staging\"}"
+            "variables": "{\"environment\":\"staging\"}"
           }
         }
       },
@@ -166,8 +66,9 @@
               "name": "test-account-updated",
               "path": null,
               "provider": "AWS",
+              "securityContext": "arn:aws:iam::123456789012:role/stacklet-execution-new",
               "shortName": "test-updated",
-              "variables": "{\"environment\": \"staging\"}"
+              "variables": "{\"environment\":\"staging\"}"
             }
           }
         }
@@ -189,6 +90,112 @@
             "account": {
               "key": "999999999999"
             }
+          }
+        }
+      }
+    }
+  ],
+  "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}:{\"key\":\"999999999999\",\"provider\":\"AWS\"}": [
+    {
+      "request": {
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
+        "variables": {
+          "key": "999999999999",
+          "provider": "AWS"
+        }
+      },
+      "response": {
+        "data": {
+          "account": {
+            "active": true,
+            "description": "Test AWS account",
+            "email": "test@example.com",
+            "id": "WyJhY2NvdW50IiwgImF3cyIsICI5OTk5OTk5OTk5OTkiXQ==",
+            "key": "999999999999",
+            "name": "test-account",
+            "path": null,
+            "provider": "AWS",
+            "securityContext": "arn:aws:iam::123456789012:role/stacklet-execution",
+            "shortName": "test",
+            "variables": "{\"environment\":\"test\"}"
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
+        "variables": {
+          "key": "999999999999",
+          "provider": "AWS"
+        }
+      },
+      "response": {
+        "data": {
+          "account": {
+            "active": true,
+            "description": "Test AWS account",
+            "email": "test@example.com",
+            "id": "WyJhY2NvdW50IiwgImF3cyIsICI5OTk5OTk5OTk5OTkiXQ==",
+            "key": "999999999999",
+            "name": "test-account",
+            "path": null,
+            "provider": "AWS",
+            "securityContext": "arn:aws:iam::123456789012:role/stacklet-execution",
+            "shortName": "test",
+            "variables": "{\"environment\":\"test\"}"
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
+        "variables": {
+          "key": "999999999999",
+          "provider": "AWS"
+        }
+      },
+      "response": {
+        "data": {
+          "account": {
+            "active": true,
+            "description": "Test AWS account",
+            "email": "test@example.com",
+            "id": "WyJhY2NvdW50IiwgImF3cyIsICI5OTk5OTk5OTk5OTkiXQ==",
+            "key": "999999999999",
+            "name": "test-account",
+            "path": null,
+            "provider": "AWS",
+            "securityContext": "arn:aws:iam::123456789012:role/stacklet-execution",
+            "shortName": "test",
+            "variables": "{\"environment\":\"test\"}"
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "query": "query ($key:String!$provider:CloudProvider!){account(provider: $provider, key: $key){id,key,name,shortName,description,provider,path,email,active,securityContext,variables}}",
+        "variables": {
+          "key": "999999999999",
+          "provider": "AWS"
+        }
+      },
+      "response": {
+        "data": {
+          "account": {
+            "active": true,
+            "description": "Updated AWS account",
+            "email": "updated@example.com",
+            "id": "WyJhY2NvdW50IiwgImF3cyIsICI5OTk5OTk5OTk5OTkiXQ==",
+            "key": "999999999999",
+            "name": "test-account-updated",
+            "path": null,
+            "provider": "AWS",
+            "securityContext": "arn:aws:iam::123456789012:role/stacklet-execution-new",
+            "shortName": "test-updated",
+            "variables": "{\"environment\":\"staging\"}"
           }
         }
       }

--- a/internal/api/account.go
+++ b/internal/api/account.go
@@ -8,16 +8,17 @@ import (
 
 // Account is the data returned by reading account data.
 type Account struct {
-	ID          string
-	Key         string
-	Name        string
-	ShortName   *string
-	Description *string
-	Provider    CloudProvider
-	Path        *string
-	Email       *string
-	Active      bool
-	Variables   *string
+	ID              string
+	Key             string
+	Name            string
+	ShortName       *string
+	Description     *string
+	Provider        CloudProvider
+	Path            *string
+	Email           *string
+	Active          bool
+	SecurityContext *string
+	Variables       *string
 }
 
 // AccountCreateInput is the input for creating an account.
@@ -44,7 +45,7 @@ type AccountUpdateInput struct {
 	ShortName       *string       `json:"shortName"`
 	Description     *string       `json:"description"`
 	Email           *string       `json:"email"`
-	SecurityContext *string       `json:"securityContext"`
+	SecurityContext *string       `json:"securityContext,omitempty"`
 	Variables       *string       `json:"variables"`
 }
 

--- a/internal/datasources/account.go
+++ b/internal/datasources/account.go
@@ -112,7 +112,12 @@ func (d *accountDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	data.CloudProvider = types.StringValue(string(account.Provider))
 	data.Path = tftypes.NullableString(account.Path)
 	data.Email = tftypes.NullableString(account.Email)
-	data.Variables = tftypes.NullableString(account.Variables)
-
+	data.SecurityContext = tftypes.NullableString(account.SecurityContext)
+	variablesString, err := tftypes.JSONString(account.Variables)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid content for variables", err.Error())
+		return
+	}
+	data.Variables = variablesString
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/models/account.go
+++ b/internal/models/account.go
@@ -6,6 +6,22 @@ import (
 
 // AccountResource is the model for account resources.
 type AccountResource struct {
+	ID                       types.String `tfsdk:"id"`
+	Key                      types.String `tfsdk:"key"`
+	Name                     types.String `tfsdk:"name"`
+	ShortName                types.String `tfsdk:"short_name"`
+	Description              types.String `tfsdk:"description"`
+	CloudProvider            types.String `tfsdk:"cloud_provider"`
+	Path                     types.String `tfsdk:"path"`
+	Email                    types.String `tfsdk:"email"`
+	SecurityContext          types.String `tfsdk:"security_context"`
+	SecurityContextWO        types.String `tfsdk:"security_context_wo"`
+	SecurityContextWOVersion types.String `tfsdk:"security_context_wo_version"`
+	Variables                types.String `tfsdk:"variables"`
+}
+
+// AcountDataSourcemodel is the model for account data sources.
+type AccountDataSource struct {
 	ID              types.String `tfsdk:"id"`
 	Key             types.String `tfsdk:"key"`
 	Name            types.String `tfsdk:"name"`
@@ -17,6 +33,3 @@ type AccountResource struct {
 	SecurityContext types.String `tfsdk:"security_context"`
 	Variables       types.String `tfsdk:"variables"`
 }
-
-// AcountDataSourcemodel is the model for account data sources.
-type AccountDataSource AccountResource

--- a/internal/resources/binding.go
+++ b/internal/resources/binding.go
@@ -225,7 +225,7 @@ func updateBindingModel(m *models.BindingResource, binding api.Binding) diag.Dia
 	m.System = types.BoolValue(binding.System)
 	variablesString, err := tftypes.JSONString(binding.ExecutionConfig.Variables)
 	if err != nil {
-		return diag.NewErrorDiagnostic("Invalid value for 'variables", err.Error())
+		return diag.NewErrorDiagnostic("Invalid content for variables", err.Error())
 	}
 	m.Variables = variablesString
 	return nil


### PR DESCRIPTION
[ENG-5163](https://stacklet.atlassian.net/browse/ENG-5163)

### what

- replace the plain `security_context` attribute in the account resource with a
pair of `_wo` and `_wo_version` to handle it as a secret.
- keep the `security_context` attribute as a computed one in both resource and
data source
- use JSONString to normalize variables string

### why

avoid storing the security context secret input in the state

### testing

local testing in sandbox

### docs

updated here


[ENG-5163]: https://stacklet.atlassian.net/browse/ENG-5163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ