### PR TITLE
chore: make API commands return pointers to struct

### DIFF
--- a/internal/api/account.go
+++ b/internal/api/account.go
@@ -60,7 +60,7 @@ type accountAPI struct {
 }
 
 // Read returns data for an account.
-func (a accountAPI) Read(ctx context.Context, cloudProvider string, key string) (Account, error) {
+func (a accountAPI) Read(ctx context.Context, cloudProvider string, key string) (*Account, error) {
 	var query struct {
 		Account Account `graphql:"account(provider: $provider, key: $key)"`
 	}
@@ -69,18 +69,18 @@ func (a accountAPI) Read(ctx context.Context, cloudProvider string, key string) 
 		"key":      graphql.String(key),
 	}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return query.Account, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
 	if query.Account.ID == "" || !query.Account.Active {
-		return query.Account, NotFound{"Account not found"}
+		return nil, NotFound{"Account not found"}
 	}
 
-	return query.Account, nil
+	return &query.Account, nil
 }
 
 // Create creates an account.
-func (a accountAPI) Create(ctx context.Context, i AccountCreateInput) (Account, error) {
+func (a accountAPI) Create(ctx context.Context, i AccountCreateInput) (*Account, error) {
 	var mutation struct {
 		AddAccount struct {
 			Account Account
@@ -88,14 +88,14 @@ func (a accountAPI) Create(ctx context.Context, i AccountCreateInput) (Account, 
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return mutation.AddAccount.Account, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
-	return mutation.AddAccount.Account, nil
+	return &mutation.AddAccount.Account, nil
 }
 
 // Update updates an account.
-func (a accountAPI) Update(ctx context.Context, i AccountUpdateInput) (Account, error) {
+func (a accountAPI) Update(ctx context.Context, i AccountUpdateInput) (*Account, error) {
 	var mutation struct {
 		UpdateAccount struct {
 			Account Account
@@ -103,10 +103,10 @@ func (a accountAPI) Update(ctx context.Context, i AccountUpdateInput) (Account, 
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return mutation.UpdateAccount.Account, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
-	return mutation.UpdateAccount.Account, nil
+	return &mutation.UpdateAccount.Account, nil
 }
 
 // Delete removes an account.

--- a/internal/api/account_discovery.go
+++ b/internal/api/account_discovery.go
@@ -105,24 +105,24 @@ type accountDiscoveryAPI struct {
 }
 
 // Read returns data for an account discovery.
-func (a accountDiscoveryAPI) Read(ctx context.Context, name string) (AccountDiscovery, error) {
+func (a accountDiscoveryAPI) Read(ctx context.Context, name string) (*AccountDiscovery, error) {
 	var query struct {
 		AccountDiscovery AccountDiscovery `graphql:"accountDiscovery(name: $name)"`
 	}
 	variables := map[string]any{"name": graphql.String(name)}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return query.AccountDiscovery, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
 	if query.AccountDiscovery.ID == "" {
-		return query.AccountDiscovery, NotFound{"Account discovery not found"}
+		return nil, NotFound{"Account discovery not found"}
 	}
 
-	return query.AccountDiscovery, nil
+	return &query.AccountDiscovery, nil
 }
 
 // UpsertAWS creates or updates an AWS account discovery.
-func (a accountDiscoveryAPI) UpsertAWS(ctx context.Context, input AccountDiscoveryAWSInput) (AccountDiscovery, error) {
+func (a accountDiscoveryAPI) UpsertAWS(ctx context.Context, input AccountDiscoveryAWSInput) (*AccountDiscovery, error) {
 	var mutation struct {
 		UpsertAWSAccountDiscovery struct {
 			AccountDiscovery AccountDiscovery
@@ -130,13 +130,13 @@ func (a accountDiscoveryAPI) UpsertAWS(ctx context.Context, input AccountDiscove
 	}
 	variables := map[string]any{"input": input}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return mutation.UpsertAWSAccountDiscovery.AccountDiscovery, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
-	return mutation.UpsertAWSAccountDiscovery.AccountDiscovery, nil
+	return &mutation.UpsertAWSAccountDiscovery.AccountDiscovery, nil
 }
 
 // UpsertAzure creates or updates an Azure account discovery.
-func (a accountDiscoveryAPI) UpsertAzure(ctx context.Context, input AccountDiscoveryAzureInput) (AccountDiscovery, error) {
+func (a accountDiscoveryAPI) UpsertAzure(ctx context.Context, input AccountDiscoveryAzureInput) (*AccountDiscovery, error) {
 	var mutation struct {
 		UpsertAzureAccountDiscovery struct {
 			AccountDiscovery AccountDiscovery
@@ -144,13 +144,13 @@ func (a accountDiscoveryAPI) UpsertAzure(ctx context.Context, input AccountDisco
 	}
 	variables := map[string]any{"input": input}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return mutation.UpsertAzureAccountDiscovery.AccountDiscovery, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
-	return mutation.UpsertAzureAccountDiscovery.AccountDiscovery, nil
+	return &mutation.UpsertAzureAccountDiscovery.AccountDiscovery, nil
 }
 
 // UpsertGCP creates or updates a GCP account discovery.
-func (a accountDiscoveryAPI) UpsertGCP(ctx context.Context, input AccountDiscoveryGCPInput) (AccountDiscovery, error) {
+func (a accountDiscoveryAPI) UpsertGCP(ctx context.Context, input AccountDiscoveryGCPInput) (*AccountDiscovery, error) {
 	var mutation struct {
 		UpsertGCPAccountDiscovery struct {
 			AccountDiscovery AccountDiscovery
@@ -158,13 +158,13 @@ func (a accountDiscoveryAPI) UpsertGCP(ctx context.Context, input AccountDiscove
 	}
 	variables := map[string]any{"input": input}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return mutation.UpsertGCPAccountDiscovery.AccountDiscovery, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
-	return mutation.UpsertGCPAccountDiscovery.AccountDiscovery, nil
+	return &mutation.UpsertGCPAccountDiscovery.AccountDiscovery, nil
 }
 
 // UpdateSuspended updates the susended flag for an account discovery.
-func (a accountDiscoveryAPI) UpdateSuspended(ctx context.Context, id string, suspended bool) (AccountDiscovery, error) {
+func (a accountDiscoveryAPI) UpdateSuspended(ctx context.Context, id string, suspended bool) (*AccountDiscovery, error) {
 	var mutation struct {
 		UpdateAccountDiscoverySchedule struct {
 			AccountDiscoveries []AccountDiscovery
@@ -181,8 +181,8 @@ func (a accountDiscoveryAPI) UpdateSuspended(ctx context.Context, id string, sus
 		},
 	}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return AccountDiscovery{}, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
-	return mutation.UpdateAccountDiscoverySchedule.AccountDiscoveries[0], nil
+	return &mutation.UpdateAccountDiscoverySchedule.AccountDiscoveries[0], nil
 }

--- a/internal/api/account_group.go
+++ b/internal/api/account_group.go
@@ -47,7 +47,7 @@ type accountGroupAPI struct {
 }
 
 // Read returns data for an account group.
-func (a accountGroupAPI) Read(ctx context.Context, uuid string, name string) (AccountGroup, error) {
+func (a accountGroupAPI) Read(ctx context.Context, uuid string, name string) (*AccountGroup, error) {
 	var query struct {
 		AccountGroup AccountGroup `graphql:"accountGroup(uuid: $uuid, name: $name)"`
 	}
@@ -57,18 +57,18 @@ func (a accountGroupAPI) Read(ctx context.Context, uuid string, name string) (Ac
 		"name": graphql.String(name),
 	}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return query.AccountGroup, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
 	if query.AccountGroup.ID == "" {
-		return query.AccountGroup, NotFound{"Account group not found"}
+		return nil, NotFound{"Account group not found"}
 	}
 
-	return query.AccountGroup, nil
+	return &query.AccountGroup, nil
 }
 
 // Create creates an account group.
-func (a accountGroupAPI) Create(ctx context.Context, i AccountGroupCreateInput) (AccountGroup, error) {
+func (a accountGroupAPI) Create(ctx context.Context, i AccountGroupCreateInput) (*AccountGroup, error) {
 	var mutation struct {
 		AddAccountGroup struct {
 			Group AccountGroup
@@ -76,14 +76,14 @@ func (a accountGroupAPI) Create(ctx context.Context, i AccountGroupCreateInput) 
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return mutation.AddAccountGroup.Group, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
-	return mutation.AddAccountGroup.Group, nil
+	return &mutation.AddAccountGroup.Group, nil
 }
 
 // Update updates an account group.
-func (a accountGroupAPI) Update(ctx context.Context, i AccountGroupUpdateInput) (AccountGroup, error) {
+func (a accountGroupAPI) Update(ctx context.Context, i AccountGroupUpdateInput) (*AccountGroup, error) {
 	var mutation struct {
 		UpdateAccountGroup struct {
 			Group AccountGroup
@@ -91,10 +91,10 @@ func (a accountGroupAPI) Update(ctx context.Context, i AccountGroupUpdateInput) 
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return mutation.UpdateAccountGroup.Group, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
-	return mutation.UpdateAccountGroup.Group, nil
+	return &mutation.UpdateAccountGroup.Group, nil
 }
 
 // Delete removes an account group.

--- a/internal/api/account_group_mapping.go
+++ b/internal/api/account_group_mapping.go
@@ -45,7 +45,7 @@ type accountGroupMappingAPI struct {
 }
 
 // Read returns data for an account group mapping.
-func (a accountGroupMappingAPI) Read(ctx context.Context, accountKey string, groupUUID string) (AccountGroupMapping, error) {
+func (a accountGroupMappingAPI) Read(ctx context.Context, accountKey string, groupUUID string) (*AccountGroupMapping, error) {
 	var query struct {
 		AccountGroup struct {
 			AccountMappings struct {
@@ -66,15 +66,15 @@ func (a accountGroupMappingAPI) Read(ctx context.Context, accountKey string, gro
 	}
 
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return AccountGroupMapping{}, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
 	if len(query.AccountGroup.AccountMappings.Edges) == 0 {
-		return AccountGroupMapping{}, NotFound{"Account group mapping not found"}
+		return nil, NotFound{"Account group mapping not found"}
 	}
 
 	node := query.AccountGroup.AccountMappings.Edges[0].Node
-	return AccountGroupMapping{
+	return &AccountGroupMapping{
 		ID:         node.ID,
 		GroupUUID:  groupUUID,
 		AccountKey: accountKey,
@@ -82,7 +82,7 @@ func (a accountGroupMappingAPI) Read(ctx context.Context, accountKey string, gro
 }
 
 // Create creates an account group mapping.
-func (a accountGroupMappingAPI) Create(ctx context.Context, accountKey string, groupUUID string) (AccountGroupMapping, error) {
+func (a accountGroupMappingAPI) Create(ctx context.Context, accountKey string, groupUUID string) (*AccountGroupMapping, error) {
 	var mutation struct {
 		UpsertAccountGroupMappings struct {
 			Mappings []struct {
@@ -103,10 +103,10 @@ func (a accountGroupMappingAPI) Create(ctx context.Context, accountKey string, g
 
 	err := a.c.Mutate(ctx, &mutation, variables)
 	if err != nil {
-		return AccountGroupMapping{}, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
-	return AccountGroupMapping{
+	return &AccountGroupMapping{
 		ID:         mutation.UpsertAccountGroupMappings.Mappings[0].ID,
 		AccountKey: accountKey,
 		GroupUUID:  groupUUID,

--- a/internal/api/binding.go
+++ b/internal/api/binding.go
@@ -67,7 +67,7 @@ type bindingAPI struct {
 }
 
 // Read returns data for a binding.
-func (a bindingAPI) Read(ctx context.Context, uuid string, name string) (Binding, error) {
+func (a bindingAPI) Read(ctx context.Context, uuid string, name string) (*Binding, error) {
 	var query struct {
 		Binding Binding `graphql:"binding(uuid: $uuid, name: $name)"`
 	}
@@ -76,17 +76,17 @@ func (a bindingAPI) Read(ctx context.Context, uuid string, name string) (Binding
 		"name": graphql.String(name),
 	}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return query.Binding, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 	if query.Binding.ID == "" {
-		return query.Binding, NotFound{"Binding not found"}
+		return nil, NotFound{"Binding not found"}
 	}
 
-	return query.Binding, nil
+	return &query.Binding, nil
 }
 
 // Create creates a binding.
-func (a bindingAPI) Create(ctx context.Context, i BindingCreateInput) (Binding, error) {
+func (a bindingAPI) Create(ctx context.Context, i BindingCreateInput) (*Binding, error) {
 	var mutation struct {
 		AddBinding struct {
 			Binding Binding
@@ -94,14 +94,14 @@ func (a bindingAPI) Create(ctx context.Context, i BindingCreateInput) (Binding, 
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return mutation.AddBinding.Binding, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
-	return mutation.AddBinding.Binding, nil
+	return &mutation.AddBinding.Binding, nil
 }
 
 // Update updates a binding.
-func (a bindingAPI) Update(ctx context.Context, i BindingUpdateInput) (Binding, error) {
+func (a bindingAPI) Update(ctx context.Context, i BindingUpdateInput) (*Binding, error) {
 	var mutation struct {
 		UpdateBinding struct {
 			Binding Binding
@@ -109,10 +109,10 @@ func (a bindingAPI) Update(ctx context.Context, i BindingUpdateInput) (Binding, 
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return mutation.UpdateBinding.Binding, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
-	return mutation.UpdateBinding.Binding, nil
+	return &mutation.UpdateBinding.Binding, nil
 }
 
 // Delete removes a binding.

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -31,7 +31,7 @@ type policyAPI struct {
 }
 
 // Read returns data for a policy.
-func (a policyAPI) Read(ctx context.Context, uuid string, name string, version int) (Policy, error) {
+func (a policyAPI) Read(ctx context.Context, uuid string, name string, version int) (*Policy, error) {
 	var query struct {
 		Policy Policy `graphql:"policy(uuid: $uuid, name: $name, version: $version)"`
 	}
@@ -41,12 +41,12 @@ func (a policyAPI) Read(ctx context.Context, uuid string, name string, version i
 		"version": graphql.Int(version),
 	}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return query.Policy, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
 	if query.Policy.ID == "" {
-		return query.Policy, NotFound{"Policy not found"}
+		return nil, NotFound{"Policy not found"}
 	}
 
-	return query.Policy, nil
+	return &query.Policy, nil
 }

--- a/internal/api/policy_collection.go
+++ b/internal/api/policy_collection.go
@@ -52,7 +52,7 @@ type policyCollectionAPI struct {
 }
 
 // Read returns data for an account.
-func (a policyCollectionAPI) Read(ctx context.Context, uuid string, name string) (PolicyCollection, error) {
+func (a policyCollectionAPI) Read(ctx context.Context, uuid string, name string) (*PolicyCollection, error) {
 	var query struct {
 		PolicyCollection PolicyCollection `graphql:"policyCollection(uuid: $uuid, name: $name)"`
 	}
@@ -61,18 +61,18 @@ func (a policyCollectionAPI) Read(ctx context.Context, uuid string, name string)
 		"name": graphql.String(name),
 	}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return query.PolicyCollection, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
 	if query.PolicyCollection.ID == "" {
-		return query.PolicyCollection, NotFound{"Policy collection not found"}
+		return nil, NotFound{"Policy collection not found"}
 	}
 
-	return query.PolicyCollection, nil
+	return &query.PolicyCollection, nil
 }
 
 // Create creates a policy collection.
-func (a policyCollectionAPI) Create(ctx context.Context, i PolicyCollectionCreateInput) (PolicyCollection, error) {
+func (a policyCollectionAPI) Create(ctx context.Context, i PolicyCollectionCreateInput) (*PolicyCollection, error) {
 	var mutation struct {
 		AddPolicyCollection struct {
 			Collection PolicyCollection
@@ -80,13 +80,13 @@ func (a policyCollectionAPI) Create(ctx context.Context, i PolicyCollectionCreat
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return mutation.AddPolicyCollection.Collection, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
-	return mutation.AddPolicyCollection.Collection, nil
+	return &mutation.AddPolicyCollection.Collection, nil
 }
 
 // Update updates a policy collection.
-func (a policyCollectionAPI) Update(ctx context.Context, i PolicyCollectionUpdateInput) (PolicyCollection, error) {
+func (a policyCollectionAPI) Update(ctx context.Context, i PolicyCollectionUpdateInput) (*PolicyCollection, error) {
 	var mutation struct {
 		UpdatePolicyCollection struct {
 			Collection PolicyCollection
@@ -94,10 +94,10 @@ func (a policyCollectionAPI) Update(ctx context.Context, i PolicyCollectionUpdat
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return mutation.UpdatePolicyCollection.Collection, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
-	return mutation.UpdatePolicyCollection.Collection, nil
+	return &mutation.UpdatePolicyCollection.Collection, nil
 }
 
 // Delete removes a policy collection.

--- a/internal/api/policy_collection_mapping.go
+++ b/internal/api/policy_collection_mapping.go
@@ -52,7 +52,7 @@ type policyCollectionMappingAPI struct {
 }
 
 // Read returns data for a policy collection mapping.
-func (a policyCollectionMappingAPI) Read(ctx context.Context, collectionUUID string, policyUUID string) (PolicyCollectionMapping, error) {
+func (a policyCollectionMappingAPI) Read(ctx context.Context, collectionUUID string, policyUUID string) (*PolicyCollectionMapping, error) {
 	var query struct {
 		PolicyCollection struct {
 			PolicyMappings struct {
@@ -67,20 +67,20 @@ func (a policyCollectionMappingAPI) Read(ctx context.Context, collectionUUID str
 		"uuid": graphql.String(collectionUUID),
 	}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return PolicyCollectionMapping{}, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
 	for _, edge := range query.PolicyCollection.PolicyMappings.Edges {
 		if edge.Node.Policy.UUID == policyUUID {
-			return edge.Node, nil
+			return &edge.Node, nil
 		}
 	}
 
-	return PolicyCollectionMapping{}, NotFound{"Policy collection not found"}
+	return nil, NotFound{"Policy collection not found"}
 }
 
 // Upsert creates or updates a policy collection mapping.
-func (a policyCollectionMappingAPI) Upsert(ctx context.Context, input PolicyCollectionMappingInput) (PolicyCollectionMapping, error) {
+func (a policyCollectionMappingAPI) Upsert(ctx context.Context, input PolicyCollectionMappingInput) (*PolicyCollectionMapping, error) {
 	var mutation struct {
 		UpsertPolicyCollectionMappings struct {
 			Mappings []PolicyCollectionMapping
@@ -94,10 +94,10 @@ func (a policyCollectionMappingAPI) Upsert(ctx context.Context, input PolicyColl
 
 	err := a.c.Mutate(ctx, &mutation, variables)
 	if err != nil {
-		return PolicyCollectionMapping{}, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 
-	return mutation.UpsertPolicyCollectionMappings.Mappings[0], nil
+	return &mutation.UpsertPolicyCollectionMappings.Mappings[0], nil
 }
 
 // Delete removes a policy collection mapping.

--- a/internal/api/repository.go
+++ b/internal/api/repository.go
@@ -97,7 +97,7 @@ type repositoryAPI struct {
 	c *graphql.Client
 }
 
-func (a repositoryAPI) Read(ctx context.Context, uuid string) (Repository, error) {
+func (a repositoryAPI) Read(ctx context.Context, uuid string) (*Repository, error) {
 	var q struct {
 		Payload struct {
 			RepositoryConfig Repository
@@ -105,12 +105,12 @@ func (a repositoryAPI) Read(ctx context.Context, uuid string) (Repository, error
 		} `graphql:"repositoryConfig(uuid: $uuid)"`
 	}
 	if err := a.c.Query(ctx, &q, map[string]any{"uuid": uuid}); err != nil {
-		return Repository{}, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 	if err := FromProblems(ctx, q.Payload.Problems); err != nil {
-		return Repository{}, err
+		return nil, err
 	}
-	return q.Payload.RepositoryConfig, nil
+	return &q.Payload.RepositoryConfig, nil
 }
 
 func (a repositoryAPI) FindByURL(ctx context.Context, url string) (string, error) {
@@ -149,7 +149,7 @@ func (a repositoryAPI) FindByURL(ctx context.Context, url string) (string, error
 	}
 }
 
-func (a repositoryAPI) Create(ctx context.Context, i RepositoryCreateInput) (Repository, error) {
+func (a repositoryAPI) Create(ctx context.Context, i RepositoryCreateInput) (*Repository, error) {
 	var m struct {
 		Payload struct {
 			RepositoryConfig Repository
@@ -157,15 +157,15 @@ func (a repositoryAPI) Create(ctx context.Context, i RepositoryCreateInput) (Rep
 		} `graphql:"addRepositoryConfig(input: $input)"`
 	}
 	if err := a.c.Mutate(ctx, &m, map[string]any{"input": i}); err != nil {
-		return Repository{}, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 	if err := FromProblems(ctx, m.Payload.Problems); err != nil {
-		return Repository{}, err
+		return nil, err
 	}
-	return m.Payload.RepositoryConfig, nil
+	return &m.Payload.RepositoryConfig, nil
 }
 
-func (a repositoryAPI) Update(ctx context.Context, i RepositoryUpdateInput) (Repository, error) {
+func (a repositoryAPI) Update(ctx context.Context, i RepositoryUpdateInput) (*Repository, error) {
 	var m struct {
 		Payload struct {
 			RepositoryConfig Repository
@@ -173,12 +173,12 @@ func (a repositoryAPI) Update(ctx context.Context, i RepositoryUpdateInput) (Rep
 		} `graphql:"updateRepositoryConfig(input: $input)"`
 	}
 	if err := a.c.Mutate(ctx, &m, map[string]any{"input": i}); err != nil {
-		return Repository{}, NewAPIError(err)
+		return nil, NewAPIError(err)
 	}
 	if err := FromProblems(ctx, m.Payload.Problems); err != nil {
-		return Repository{}, err
+		return nil, err
 	}
-	return m.Payload.RepositoryConfig, nil
+	return &m.Payload.RepositoryConfig, nil
 }
 
 func (a repositoryAPI) Delete(ctx context.Context, i RepositoryDeleteInput) error {

--- a/internal/api/sso_group.go
+++ b/internal/api/sso_group.go
@@ -1,9 +1,0 @@
-// Copyright (c) 2025 - Stacklet, Inc.
-
-package api
-
-type SSOGroupConfig struct {
-	Name              string   `json:"name"`
-	Roles             []string `json:"roles"`
-	AccountGroupUUIDs []string `graphql:"accountGroupUUIDs"`
-}

--- a/internal/resources/account.go
+++ b/internal/resources/account.go
@@ -233,7 +233,7 @@ func (r *accountResource) ImportState(ctx context.Context, req resource.ImportSt
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("key"), parts[1])...)
 }
 
-func updateAccountModel(m *models.AccountResource, account api.Account) diag.Diagnostic {
+func updateAccountModel(m *models.AccountResource, account *api.Account) diag.Diagnostic {
 	m.ID = types.StringValue(account.ID)
 	m.Key = types.StringValue(account.Key)
 	m.Name = types.StringValue(account.Name)

--- a/internal/resources/account_discovery_aws.go
+++ b/internal/resources/account_discovery_aws.go
@@ -190,7 +190,7 @@ func (r *accountDiscoveryAWSResource) ImportState(ctx context.Context, req resou
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), req.ID)...)
 }
 
-func updateAccountDiscoveryAWSModel(m *models.AccountDiscoveryAWSResource, accountDiscovery api.AccountDiscovery) {
+func updateAccountDiscoveryAWSModel(m *models.AccountDiscoveryAWSResource, accountDiscovery *api.AccountDiscovery) {
 	m.ID = types.StringValue(accountDiscovery.ID)
 	m.Name = types.StringValue(accountDiscovery.Name)
 	m.Description = tftypes.NullableString(accountDiscovery.Description)

--- a/internal/resources/account_discovery_azure.go
+++ b/internal/resources/account_discovery_azure.go
@@ -193,7 +193,7 @@ func (r *accountDiscoveryAzureResource) ImportState(ctx context.Context, req res
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), req.ID)...)
 }
 
-func updateAccountDiscoveryAzureModel(m *models.AccountDiscoveryAzureResource, accountDiscovery api.AccountDiscovery) {
+func updateAccountDiscoveryAzureModel(m *models.AccountDiscoveryAzureResource, accountDiscovery *api.AccountDiscovery) {
 	m.ID = types.StringValue(accountDiscovery.ID)
 	m.Name = types.StringValue(accountDiscovery.Name)
 	m.Description = tftypes.NullableString(accountDiscovery.Description)

--- a/internal/resources/account_discovery_gcp.go
+++ b/internal/resources/account_discovery_gcp.go
@@ -218,7 +218,7 @@ func (r *accountDiscoveryGCPResource) ImportState(ctx context.Context, req resou
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), req.ID)...)
 }
 
-func updateAccountDiscoveryGCPModel(m *models.AccountDiscoveryGCPResource, accountDiscovery api.AccountDiscovery) {
+func updateAccountDiscoveryGCPModel(m *models.AccountDiscoveryGCPResource, accountDiscovery *api.AccountDiscovery) {
 	m.ID = types.StringValue(accountDiscovery.ID)
 	m.Name = types.StringValue(accountDiscovery.Name)
 	m.Description = tftypes.NullableString(accountDiscovery.Description)

--- a/internal/resources/account_group.go
+++ b/internal/resources/account_group.go
@@ -171,7 +171,7 @@ func (r *accountGroupResource) ImportState(ctx context.Context, req resource.Imp
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("uuid"), req.ID)...)
 }
 
-func updateAccountGroupModel(m *models.AccountGroupResource, account_group api.AccountGroup) {
+func updateAccountGroupModel(m *models.AccountGroupResource, account_group *api.AccountGroup) {
 	m.ID = types.StringValue(account_group.ID)
 	m.UUID = types.StringValue(account_group.UUID)
 	m.Name = types.StringValue(account_group.Name)

--- a/internal/resources/account_group_mapping.go
+++ b/internal/resources/account_group_mapping.go
@@ -144,7 +144,7 @@ func (r *accountGroupMappingResource) ImportState(ctx context.Context, req resou
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("account_key"), parts[1])...)
 }
 
-func updateAccountGroupMappingModel(m *models.AccountGroupMappingResource, accountGroupMapping api.AccountGroupMapping) {
+func updateAccountGroupMappingModel(m *models.AccountGroupMappingResource, accountGroupMapping *api.AccountGroupMapping) {
 	m.ID = types.StringValue(accountGroupMapping.ID)
 	m.GroupUUID = types.StringValue(accountGroupMapping.GroupUUID)
 	m.AccountKey = types.StringValue(accountGroupMapping.AccountKey)

--- a/internal/resources/binding.go
+++ b/internal/resources/binding.go
@@ -210,7 +210,7 @@ func (r *bindingResource) ImportState(ctx context.Context, req resource.ImportSt
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("uuid"), req.ID)...)
 }
 
-func updateBindingModel(m *models.BindingResource, binding api.Binding) diag.Diagnostic {
+func updateBindingModel(m *models.BindingResource, binding *api.Binding) diag.Diagnostic {
 	m.ID = types.StringValue(binding.ID)
 	m.UUID = types.StringValue(binding.UUID)
 	m.Name = types.StringValue(binding.Name)

--- a/internal/resources/policy_collection.go
+++ b/internal/resources/policy_collection.go
@@ -196,7 +196,7 @@ func (r *policyCollectionResource) ImportState(ctx context.Context, req resource
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("uuid"), req.ID)...)
 }
 
-func updatePolicyCollectionModel(m *models.PolicyCollectionResource, policyCollection api.PolicyCollection) {
+func updatePolicyCollectionModel(m *models.PolicyCollectionResource, policyCollection *api.PolicyCollection) {
 	m.ID = types.StringValue(policyCollection.ID)
 	m.UUID = types.StringValue(policyCollection.UUID)
 	m.Name = types.StringValue(policyCollection.Name)

--- a/internal/resources/policy_collection_mapping.go
+++ b/internal/resources/policy_collection_mapping.go
@@ -163,7 +163,7 @@ func (r *policyCollectionMappingResource) ImportState(ctx context.Context, req r
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("policy_uuid"), parts[1])...)
 }
 
-func updatePolicyCollectionMappingModel(m *models.PolicyCollectionMappingResource, policyCollectionMapping api.PolicyCollectionMapping) {
+func updatePolicyCollectionMappingModel(m *models.PolicyCollectionMappingResource, policyCollectionMapping *api.PolicyCollectionMapping) {
 	m.ID = types.StringValue(policyCollectionMapping.ID)
 	m.CollectionUUID = types.StringValue(policyCollectionMapping.Collection.UUID)
 	m.PolicyUUID = types.StringValue(policyCollectionMapping.Policy.UUID)

--- a/internal/resources/repository.go
+++ b/internal/resources/repository.go
@@ -277,7 +277,7 @@ func (r *RepositoryResource) ImportState(ctx context.Context, req resource.Impor
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("uuid"), uuid)...)
 }
 
-func updateRepositoryModel(m *models.RepositoryResource, repo api.Repository) {
+func updateRepositoryModel(m *models.RepositoryResource, repo *api.Repository) {
 	m.ID = types.StringValue(repo.ID)
 	m.UUID = types.StringValue(repo.UUID)
 	m.URL = types.StringValue(repo.URL)


### PR DESCRIPTION
### what

return pointers rather than structs from API methods

### why

avoid returning possibly empty objects in case of error.
This ensures a proper error (nil pointer dereference) in case the error isn't
handled, otherwise code might be silently doing the wrong thing by processing
an empty object.

### testing

unit tests

### docs

n/a
