### PR TITLE
chore: rename mutation fields to Payload for consistency

### DIFF
--- a/internal/api/account.go
+++ b/internal/api/account.go
@@ -82,7 +82,7 @@ func (a accountAPI) Read(ctx context.Context, cloudProvider string, key string) 
 // Create creates an account.
 func (a accountAPI) Create(ctx context.Context, i AccountCreateInput) (*Account, error) {
 	var mutation struct {
-		AddAccount struct {
+		Payload struct {
 			Account Account
 		} `graphql:"addAccount(input: $input)"`
 	}
@@ -91,13 +91,13 @@ func (a accountAPI) Create(ctx context.Context, i AccountCreateInput) (*Account,
 		return nil, NewAPIError(err)
 	}
 
-	return &mutation.AddAccount.Account, nil
+	return &mutation.Payload.Account, nil
 }
 
 // Update updates an account.
 func (a accountAPI) Update(ctx context.Context, i AccountUpdateInput) (*Account, error) {
 	var mutation struct {
-		UpdateAccount struct {
+		Payload struct {
 			Account Account
 		} `graphql:"updateAccount(input: $input)"`
 	}
@@ -106,13 +106,13 @@ func (a accountAPI) Update(ctx context.Context, i AccountUpdateInput) (*Account,
 		return nil, NewAPIError(err)
 	}
 
-	return &mutation.UpdateAccount.Account, nil
+	return &mutation.Payload.Account, nil
 }
 
 // Delete removes an account.
 func (a accountAPI) Delete(ctx context.Context, cloudProvider string, key string) error {
 	var mutation struct {
-		RemoveAccount struct {
+		Payload struct {
 			Account struct {
 				Key string
 			}

--- a/internal/api/account_discovery.go
+++ b/internal/api/account_discovery.go
@@ -124,7 +124,7 @@ func (a accountDiscoveryAPI) Read(ctx context.Context, name string) (*AccountDis
 // UpsertAWS creates or updates an AWS account discovery.
 func (a accountDiscoveryAPI) UpsertAWS(ctx context.Context, input AccountDiscoveryAWSInput) (*AccountDiscovery, error) {
 	var mutation struct {
-		UpsertAWSAccountDiscovery struct {
+		Payload struct {
 			AccountDiscovery AccountDiscovery
 		} `graphql:"upsertAWSAccountDiscovery(input: $input)"`
 	}
@@ -132,13 +132,13 @@ func (a accountDiscoveryAPI) UpsertAWS(ctx context.Context, input AccountDiscove
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
 		return nil, NewAPIError(err)
 	}
-	return &mutation.UpsertAWSAccountDiscovery.AccountDiscovery, nil
+	return &mutation.Payload.AccountDiscovery, nil
 }
 
 // UpsertAzure creates or updates an Azure account discovery.
 func (a accountDiscoveryAPI) UpsertAzure(ctx context.Context, input AccountDiscoveryAzureInput) (*AccountDiscovery, error) {
 	var mutation struct {
-		UpsertAzureAccountDiscovery struct {
+		Payload struct {
 			AccountDiscovery AccountDiscovery
 		} `graphql:"upsertAzureAccountDiscovery(input: $input)"`
 	}
@@ -146,13 +146,13 @@ func (a accountDiscoveryAPI) UpsertAzure(ctx context.Context, input AccountDisco
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
 		return nil, NewAPIError(err)
 	}
-	return &mutation.UpsertAzureAccountDiscovery.AccountDiscovery, nil
+	return &mutation.Payload.AccountDiscovery, nil
 }
 
 // UpsertGCP creates or updates a GCP account discovery.
 func (a accountDiscoveryAPI) UpsertGCP(ctx context.Context, input AccountDiscoveryGCPInput) (*AccountDiscovery, error) {
 	var mutation struct {
-		UpsertGCPAccountDiscovery struct {
+		Payload struct {
 			AccountDiscovery AccountDiscovery
 		} `graphql:"upsertGCPAccountDiscovery(input: $input)"`
 	}
@@ -160,13 +160,13 @@ func (a accountDiscoveryAPI) UpsertGCP(ctx context.Context, input AccountDiscove
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
 		return nil, NewAPIError(err)
 	}
-	return &mutation.UpsertGCPAccountDiscovery.AccountDiscovery, nil
+	return &mutation.Payload.AccountDiscovery, nil
 }
 
 // UpdateSuspended updates the susended flag for an account discovery.
 func (a accountDiscoveryAPI) UpdateSuspended(ctx context.Context, id string, suspended bool) (*AccountDiscovery, error) {
 	var mutation struct {
-		UpdateAccountDiscoverySchedule struct {
+		Payload struct {
 			AccountDiscoveries []AccountDiscovery
 		} `graphql:"updateAccountDiscoverySchedule(input: $input)"`
 	}
@@ -184,5 +184,5 @@ func (a accountDiscoveryAPI) UpdateSuspended(ctx context.Context, id string, sus
 		return nil, NewAPIError(err)
 	}
 
-	return &mutation.UpdateAccountDiscoverySchedule.AccountDiscoveries[0], nil
+	return &mutation.Payload.AccountDiscoveries[0], nil
 }

--- a/internal/api/account_group.go
+++ b/internal/api/account_group.go
@@ -70,7 +70,7 @@ func (a accountGroupAPI) Read(ctx context.Context, uuid string, name string) (*A
 // Create creates an account group.
 func (a accountGroupAPI) Create(ctx context.Context, i AccountGroupCreateInput) (*AccountGroup, error) {
 	var mutation struct {
-		AddAccountGroup struct {
+		Payload struct {
 			Group AccountGroup
 		} `graphql:"addAccountGroup(input: $input)"`
 	}
@@ -79,13 +79,13 @@ func (a accountGroupAPI) Create(ctx context.Context, i AccountGroupCreateInput) 
 		return nil, NewAPIError(err)
 	}
 
-	return &mutation.AddAccountGroup.Group, nil
+	return &mutation.Payload.Group, nil
 }
 
 // Update updates an account group.
 func (a accountGroupAPI) Update(ctx context.Context, i AccountGroupUpdateInput) (*AccountGroup, error) {
 	var mutation struct {
-		UpdateAccountGroup struct {
+		Payload struct {
 			Group AccountGroup
 		} `graphql:"updateAccountGroup(input: $input)"`
 	}
@@ -94,13 +94,13 @@ func (a accountGroupAPI) Update(ctx context.Context, i AccountGroupUpdateInput) 
 		return nil, NewAPIError(err)
 	}
 
-	return &mutation.UpdateAccountGroup.Group, nil
+	return &mutation.Payload.Group, nil
 }
 
 // Delete removes an account group.
 func (a accountGroupAPI) Delete(ctx context.Context, uuid string) error {
 	var mutation struct {
-		RemoveAccountGroup struct {
+		Payload struct {
 			Group struct {
 				UUID string
 			}

--- a/internal/api/account_group_mapping.go
+++ b/internal/api/account_group_mapping.go
@@ -84,7 +84,7 @@ func (a accountGroupMappingAPI) Read(ctx context.Context, accountKey string, gro
 // Create creates an account group mapping.
 func (a accountGroupMappingAPI) Create(ctx context.Context, accountKey string, groupUUID string) (*AccountGroupMapping, error) {
 	var mutation struct {
-		UpsertAccountGroupMappings struct {
+		Payload struct {
 			Mappings []struct {
 				ID string
 			}
@@ -107,7 +107,7 @@ func (a accountGroupMappingAPI) Create(ctx context.Context, accountKey string, g
 	}
 
 	return &AccountGroupMapping{
-		ID:         mutation.UpsertAccountGroupMappings.Mappings[0].ID,
+		ID:         mutation.Payload.Mappings[0].ID,
 		AccountKey: accountKey,
 		GroupUUID:  groupUUID,
 	}, nil
@@ -116,7 +116,7 @@ func (a accountGroupMappingAPI) Create(ctx context.Context, accountKey string, g
 // Delete removes an account group mapping.
 func (a accountGroupMappingAPI) Delete(ctx context.Context, id string) error {
 	var mutation struct {
-		RemoveAccountGroupMappings struct {
+		Payload struct {
 			Removed []struct {
 				ID string
 			}

--- a/internal/api/binding.go
+++ b/internal/api/binding.go
@@ -88,7 +88,7 @@ func (a bindingAPI) Read(ctx context.Context, uuid string, name string) (*Bindin
 // Create creates a binding.
 func (a bindingAPI) Create(ctx context.Context, i BindingCreateInput) (*Binding, error) {
 	var mutation struct {
-		AddBinding struct {
+		Payload struct {
 			Binding Binding
 		} `graphql:"addBinding(input: $input)"`
 	}
@@ -97,13 +97,13 @@ func (a bindingAPI) Create(ctx context.Context, i BindingCreateInput) (*Binding,
 		return nil, NewAPIError(err)
 	}
 
-	return &mutation.AddBinding.Binding, nil
+	return &mutation.Payload.Binding, nil
 }
 
 // Update updates a binding.
 func (a bindingAPI) Update(ctx context.Context, i BindingUpdateInput) (*Binding, error) {
 	var mutation struct {
-		UpdateBinding struct {
+		Payload struct {
 			Binding Binding
 		} `graphql:"updateBinding(input: $input)"`
 	}
@@ -112,13 +112,13 @@ func (a bindingAPI) Update(ctx context.Context, i BindingUpdateInput) (*Binding,
 		return nil, NewAPIError(err)
 	}
 
-	return &mutation.UpdateBinding.Binding, nil
+	return &mutation.Payload.Binding, nil
 }
 
 // Delete removes a binding.
 func (a bindingAPI) Delete(ctx context.Context, uuid string) error {
 	var mutation struct {
-		RemoveBinding struct {
+		Payload struct {
 			Binding struct {
 				UUID string
 			}

--- a/internal/api/policy_collection.go
+++ b/internal/api/policy_collection.go
@@ -74,7 +74,7 @@ func (a policyCollectionAPI) Read(ctx context.Context, uuid string, name string)
 // Create creates a policy collection.
 func (a policyCollectionAPI) Create(ctx context.Context, i PolicyCollectionCreateInput) (*PolicyCollection, error) {
 	var mutation struct {
-		AddPolicyCollection struct {
+		Payload struct {
 			Collection PolicyCollection
 		} `graphql:"addPolicyCollection(input: $input)"`
 	}
@@ -82,13 +82,13 @@ func (a policyCollectionAPI) Create(ctx context.Context, i PolicyCollectionCreat
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
 		return nil, NewAPIError(err)
 	}
-	return &mutation.AddPolicyCollection.Collection, nil
+	return &mutation.Payload.Collection, nil
 }
 
 // Update updates a policy collection.
 func (a policyCollectionAPI) Update(ctx context.Context, i PolicyCollectionUpdateInput) (*PolicyCollection, error) {
 	var mutation struct {
-		UpdatePolicyCollection struct {
+		Payload struct {
 			Collection PolicyCollection
 		} `graphql:"updatePolicyCollection(input: $input)"`
 	}
@@ -97,13 +97,13 @@ func (a policyCollectionAPI) Update(ctx context.Context, i PolicyCollectionUpdat
 		return nil, NewAPIError(err)
 	}
 
-	return &mutation.UpdatePolicyCollection.Collection, nil
+	return &mutation.Payload.Collection, nil
 }
 
 // Delete removes a policy collection.
 func (a policyCollectionAPI) Delete(ctx context.Context, uuid string) error {
 	var mutation struct {
-		RemovePolicyCollection struct {
+		Payload struct {
 			Collection struct {
 				UUID string
 			}

--- a/internal/api/policy_collection_mapping.go
+++ b/internal/api/policy_collection_mapping.go
@@ -82,7 +82,7 @@ func (a policyCollectionMappingAPI) Read(ctx context.Context, collectionUUID str
 // Upsert creates or updates a policy collection mapping.
 func (a policyCollectionMappingAPI) Upsert(ctx context.Context, input PolicyCollectionMappingInput) (*PolicyCollectionMapping, error) {
 	var mutation struct {
-		UpsertPolicyCollectionMappings struct {
+		Payload struct {
 			Mappings []PolicyCollectionMapping
 		} `graphql:"upsertPolicyCollectionMappings(input: $input)"`
 	}
@@ -97,13 +97,13 @@ func (a policyCollectionMappingAPI) Upsert(ctx context.Context, input PolicyColl
 		return nil, NewAPIError(err)
 	}
 
-	return &mutation.UpsertPolicyCollectionMappings.Mappings[0], nil
+	return &mutation.Payload.Mappings[0], nil
 }
 
 // Delete removes a policy collection mapping.
 func (a policyCollectionMappingAPI) Delete(ctx context.Context, id string) error {
 	var mutation struct {
-		RemovePolicyCollectionMappings struct {
+		Payload struct {
 			Removed []struct {
 				ID string
 			}


### PR DESCRIPTION
### what

always call the field in a mutation var `Payload`

### why

consistency (and brevity)

### testing

unit tests

### docs

n/a
