### PR TITLE
fix: make all acceptance tests runnable on sandbox [ENG-5098]

### DIFF
--- a/internal/acceptance_tests/account_group_mapping_resource_test.go
+++ b/internal/acceptance_tests/account_group_mapping_resource_test.go
@@ -3,11 +3,9 @@
 package acceptance_tests
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccAccountGroupMappingResource(t *testing.T) {
@@ -52,13 +50,10 @@ func TestAccAccountGroupMappingResource(t *testing.T) {
 			ResourceName:      "stacklet_account_group_mapping.test",
 			ImportState:       true,
 			ImportStateVerify: true,
-			ImportStateIdFunc: func(s *terraform.State) (string, error) {
-				rs, ok := s.RootModule().Resources["stacklet_account_group_mapping.test"]
-				if !ok {
-					return "", fmt.Errorf("resource not found in state")
-				}
-				return fmt.Sprintf("%s:%s", rs.Primary.Attributes["group_uuid"], rs.Primary.Attributes["account_key"]), nil
-			},
+			ImportStateIdFunc: importStateIDFuncFromAttrs(
+				"stacklet_account_group_mapping.test.group_uuid",
+				"stacklet_account_group_mapping.test.account_key",
+			),
 		},
 		// Update and Read testing
 		{

--- a/internal/acceptance_tests/account_group_resource_test.go
+++ b/internal/acceptance_tests/account_group_resource_test.go
@@ -33,7 +33,7 @@ func TestAccAccountGroupResource(t *testing.T) {
 			ResourceName:      "stacklet_account_group.test",
 			ImportState:       true,
 			ImportStateVerify: true,
-			ImportStateId:     "d9784826-dba3-4bb1-8df3-3dd60c8983e1",
+			ImportStateIdFunc: importStateIDFuncFromAttrs("stacklet_account_group.test.uuid"),
 		},
 		// Update and Read testing
 		{

--- a/internal/acceptance_tests/account_resource_test.go
+++ b/internal/acceptance_tests/account_resource_test.go
@@ -45,8 +45,11 @@ func TestAccAccountResource(t *testing.T) {
 			ResourceName:            "stacklet_account.test",
 			ImportState:             true,
 			ImportStateVerify:       true,
-			ImportStateId:           "AWS:999999999999",
-			ImportStateVerifyIgnore: []string{"security_context"},
+			ImportStateVerifyIgnore: []string{"security_context_wo"},
+			ImportStateIdFunc: importStateIDFuncFromAttrs(
+				"stacklet_account.test.cloud_provider",
+				"stacklet_account.test.key",
+			),
 		},
 		// Update and Read testing
 		{

--- a/internal/acceptance_tests/binding_resource_test.go
+++ b/internal/acceptance_tests/binding_resource_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccBindingResource(t *testing.T) {
@@ -56,10 +55,7 @@ func TestAccBindingResource(t *testing.T) {
 			ResourceName:      "stacklet_binding.test",
 			ImportState:       true,
 			ImportStateVerify: true,
-			ImportStateIdFunc: func(s *terraform.State) (string, error) {
-				r := s.RootModule().Resources["stacklet_binding.test"]
-				return r.Primary.Attributes["uuid"], nil
-			},
+			ImportStateIdFunc: importStateIDFuncFromAttrs("stacklet_binding.test.uuid"),
 		},
 		// Update and Read testing
 		{

--- a/internal/acceptance_tests/policy_collection_item_resource_test.go
+++ b/internal/acceptance_tests/policy_collection_item_resource_test.go
@@ -3,11 +3,9 @@
 package acceptance_tests
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccPolicyCollectionMappingResource(t *testing.T) {
@@ -46,17 +44,10 @@ func TestAccPolicyCollectionMappingResource(t *testing.T) {
 			ResourceName:      "stacklet_policy_collection_mapping.test",
 			ImportState:       true,
 			ImportStateVerify: true,
-			ImportStateIdFunc: func(s *terraform.State) (string, error) {
-				policyCollection, ok := s.RootModule().Resources["stacklet_policy_collection.test"]
-				if !ok {
-					return "", fmt.Errorf("resource not found in state")
-				}
-				policy, ok := s.RootModule().Resources["data.stacklet_policy.policy1"]
-				if !ok {
-					return "", fmt.Errorf("data source not found in state")
-				}
-				return fmt.Sprintf("%s:%s", policyCollection.Primary.Attributes["uuid"], policy.Primary.Attributes["uuid"]), nil
-			},
+			ImportStateIdFunc: importStateIDFuncFromAttrs(
+				"stacklet_policy_collection.test.uuid",
+				"data.stacklet_policy.policy1.uuid",
+			),
 		},
 		// Update and Read testing
 		{

--- a/internal/acceptance_tests/policy_collection_resource_test.go
+++ b/internal/acceptance_tests/policy_collection_resource_test.go
@@ -3,11 +3,9 @@
 package acceptance_tests
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccPolicyCollectionResource(t *testing.T) {
@@ -32,13 +30,7 @@ func TestAccPolicyCollectionResource(t *testing.T) {
 			ResourceName:      "stacklet_policy_collection.test",
 			ImportState:       true,
 			ImportStateVerify: true,
-			ImportStateIdFunc: func(s *terraform.State) (string, error) {
-				rs, ok := s.RootModule().Resources["stacklet_policy_collection.test"]
-				if !ok {
-					return "", fmt.Errorf("resource not found in state")
-				}
-				return rs.Primary.Attributes["uuid"], nil
-			},
+			ImportStateIdFunc: importStateIDFuncFromAttrs("stacklet_policy_collection.test.uuid"),
 		},
 		// Update and Read testing
 		{

--- a/internal/acceptance_tests/recorded_transport.go
+++ b/internal/acceptance_tests/recorded_transport.go
@@ -60,7 +60,7 @@ func newRecordedTransport(t *testing.T, testName string, wrapped http.RoundTripp
 	}
 }
 
-func (rt *recordedTransport) loadRecordings() error {
+func (rt *recordedTransport) loadRecording() error {
 	if rt.mode == "record" {
 		return nil
 	}
@@ -74,7 +74,7 @@ func (rt *recordedTransport) loadRecordings() error {
 	return json.Unmarshal(data, &rt.recordings)
 }
 
-func (rt *recordedTransport) saveRecordings() error {
+func (rt *recordedTransport) saveRecording() error {
 	if rt.mode != "record" {
 		return nil
 	}

--- a/internal/acceptance_tests/repository_resource_test.go
+++ b/internal/acceptance_tests/repository_resource_test.go
@@ -44,7 +44,7 @@ func TestAccRepositoryResourceAttrs(t *testing.T) {
 			ResourceName:      "stacklet_repository.test",
 			ImportState:       true,
 			ImportStateVerify: true,
-			ImportStateId:     "https://github.com/test-org/test-repo",
+			ImportStateIdFunc: importStateIDFuncFromAttrs("stacklet_repository.test.url"),
 		},
 	}
 	runRecordedAccTest(t, "TestAccRepositoryResourceAttrs", steps)

--- a/internal/acceptance_tests/testing.go
+++ b/internal/acceptance_tests/testing.go
@@ -3,31 +3,51 @@
 package acceptance_tests
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/stacklet/terraform-provider-stacklet/internal/provider"
 )
 
-// testAccProtoV6ProviderFactories are used to instantiate a provider during
-// acceptance testing. The factory function will be invoked for every Terraform
-// CLI command executed to create a new provider server to which the CLI can
-// reattach.
-var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-	"stacklet": func() (tfprotov6.ProviderServer, error) {
-		p := provider.New("test")()
-		return providerserver.NewProtocol6WithError(p)()
-	},
+// importStateIDFuncFromAttrs returns an ImportStateIdFunc that creates an
+// import ID from resource attributes. Each attribute is in the form
+// `resource.name.attr`. If multiple attributes are provided, they're joined
+// with ":".
+func importStateIDFuncFromAttrs(attrs ...string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		values := make([]string, len(attrs))
+		for i, attr := range attrs {
+			parts := strings.Split(attr, ".")
+			resource := strings.Join(parts[:len(parts)-1], ".")
+			name := parts[len(parts)-1]
+
+			res, ok := s.RootModule().Resources[resource]
+			if !ok {
+				return "", fmt.Errorf("resource '%s' not found in state", resource)
+			}
+
+			value, ok := res.Primary.Attributes[name]
+			if !ok {
+				return "", fmt.Errorf("resource '%s' doesn't have attribute '%s'", resource, attr)
+			}
+			values[i] = value
+		}
+		return strings.Join(values, ":"), nil
+	}
 }
 
+// runRecordedAccTest runs an acceptance test, with the specified name and steps.
 func runRecordedAccTest(t *testing.T, testName string, testSteps []resource.TestStep) {
 	rt := newRecordedTransport(t, testName, http.DefaultTransport)
-	if err := rt.loadRecordings(); err != nil {
-		t.Errorf("failed to load recordings: %v", err)
+	if err := rt.loadRecording(); err != nil {
+		t.Errorf("failed to load recording: %v", err)
 	}
 
 	origTransport := http.DefaultTransport
@@ -36,13 +56,18 @@ func runRecordedAccTest(t *testing.T, testName string, testSteps []resource.Test
 	t.Cleanup(func() {
 		http.DefaultTransport = origTransport
 
-		if err := rt.saveRecordings(); err != nil {
-			t.Errorf("failed to save recordings: %v", err)
+		if err := rt.saveRecording(); err != nil {
+			t.Errorf("failed to save recording: %v", err)
 		}
 	})
 
 	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps:                    testSteps,
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"stacklet": func() (tfprotov6.ProviderServer, error) {
+				p := provider.New("test")()
+				return providerserver.NewProtocol6WithError(p)()
+			},
+		},
+		Steps: testSteps,
 	})
 }


### PR DESCRIPTION
[ENG-5098](https://stacklet.atlassian.net/browse/ENG-5098)

### what

- add helper to generate the `ImportStateIdFunc` for import state tests
- update all tests to use it and not use fixed value `ImportStateId`s

### why

make it possible to run all tests against a sandbox, where UUIDs would differ
from run to run

### testing

this is updating tests

### docs

n/a


[ENG-5098]: https://stacklet.atlassian.net/browse/ENG-5098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ