### PR TITLE
chore: cleanup leftover reference to graphql client in provider data

### DIFF
--- a/internal/acceptance_tests/recorded_transport.go
+++ b/internal/acceptance_tests/recorded_transport.go
@@ -110,11 +110,13 @@ func (rt *recordedTransport) RoundTrip(req *http.Request) (*http.Response, error
 	var gqlReq graphqlRequest
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
+		req.Body.Close()
 		return nil, fmt.Errorf("failed to read request body: %v", err)
 	}
 	req.Body = io.NopCloser(bytes.NewReader(body)) // Reset the body for future reads
 
 	if err := json.Unmarshal(body, &gqlReq); err != nil {
+		req.Body.Close()
 		return nil, fmt.Errorf("failed to decode request body: %v", err)
 	}
 

--- a/internal/providerdata/providerdata.go
+++ b/internal/providerdata/providerdata.go
@@ -14,15 +14,13 @@ import (
 
 // ProviderData holds shared data for available in requests.
 type ProviderData struct {
-	API           *api.API
-	GraphQLClient *graphql.Client // XXX todo remove once all are migrated
+	API *api.API
 }
 
 // New returns a new ProviderData.
 func New(client *graphql.Client) *ProviderData {
 	return &ProviderData{
-		GraphQLClient: client,
-		API:           api.New(client),
+		API: api.New(client),
 	}
 }
 


### PR DESCRIPTION
### what

- cleanup reference to the graphql client in provider data
- ensure body is closed in http RoundTripper

### why

it's not needed anymore now that all resources/data sources use the api wrapper package

### testing

acceptance tests

### docs

n/a
