### PR TITLE
chore: move binding execution variables under execution_config

### DIFF
--- a/docs/data-sources/binding.md
+++ b/docs/data-sources/binding.md
@@ -37,8 +37,15 @@ data "stacklet_binding" "by_name" {
 - `account_group_uuid` (String) The UUID of the account group this binding applies to.
 - `auto_deploy` (Boolean) Whether the binding automatically deploys when the policy collection changes.
 - `description` (String) The description of the binding.
+- `execution_config` (Attributes) Binding execution configuration. (see [below for nested schema](#nestedatt--execution_config))
 - `id` (String) The GraphQL Node ID of the binding.
 - `policy_collection_uuid` (String) The UUID of the policy collection this binding applies.
 - `schedule` (String) The schedule for the binding (e.g., 'rate(1 hour)', 'rate(2 hours)', or cron expression).
 - `system` (Boolean) Whether this is a system binding.
+
+<a id="nestedatt--execution_config"></a>
+### Nested Schema for `execution_config`
+
+Read-Only:
+
 - `variables` (String) JSON-encoded dictionary of values used for policy templating.

--- a/docs/resources/binding.md
+++ b/docs/resources/binding.md
@@ -31,10 +31,12 @@ resource "stacklet_binding" "example" {
   auto_deploy = true
   schedule    = "rate(12 hours)"
 
-  variables = jsonencode({
-    environment = "development"
-    severity    = "medium"
-  })
+  execution_config = {
+    variables = jsonencode({
+      environment = "development"
+      severity    = "medium"
+    })
+  }
 }
 ```
 
@@ -51,14 +53,21 @@ resource "stacklet_binding" "example" {
 
 - `auto_deploy` (Boolean) Whether the binding should automatically deploy when the policy collection changes.
 - `description` (String) A description of the binding.
+- `execution_config` (Attributes) Binding execution configuration. (see [below for nested schema](#nestedatt--execution_config))
 - `schedule` (String) The schedule for the binding (e.g., 'rate(1 hour)', 'rate(2 hours)', or cron expression).
-- `variables` (String) JSON-encoded dictionary of values used for policy templating.
 
 ### Read-Only
 
 - `id` (String) The GraphQL Node ID of the binding.
 - `system` (Boolean) Whether the binding is a system one. Always false for resources.
 - `uuid` (String) The UUID of the binding.
+
+<a id="nestedatt--execution_config"></a>
+### Nested Schema for `execution_config`
+
+Optional:
+
+- `variables` (String) JSON-encoded dictionary of values used for policy templating.
 
 ## Import
 

--- a/examples/resources/stacklet_binding/resource.tf
+++ b/examples/resources/stacklet_binding/resource.tf
@@ -16,8 +16,10 @@ resource "stacklet_binding" "example" {
   auto_deploy = true
   schedule    = "rate(12 hours)"
 
-  variables = jsonencode({
-    environment = "development"
-    severity    = "medium"
-  })
+  execution_config = {
+    variables = jsonencode({
+      environment = "development"
+      severity    = "medium"
+    })
+  }
 }

--- a/internal/acceptance_tests/binding_data_source_test.go
+++ b/internal/acceptance_tests/binding_data_source_test.go
@@ -33,10 +33,12 @@ func TestAccBindingDataSource(t *testing.T) {
 						policy_collection_uuid = stacklet_policy_collection.test.uuid
 						auto_deploy = true
 						schedule = "rate(1 hour)"
-						variables = jsonencode({
-							environment = "test"
-							region = "us-east-1"
-						})
+						execution_config = {
+							variables = jsonencode({
+								environment = "test"
+								region = "us-east-1"
+							})
+						}
 					}
 
 					# Test lookup by name
@@ -59,6 +61,7 @@ func TestAccBindingDataSource(t *testing.T) {
 				resource.TestCheckResourceAttr("data.stacklet_binding.by_name", "schedule", "rate(1 hour)"),
 				resource.TestCheckResourceAttrSet("data.stacklet_binding.by_name", "id"),
 				resource.TestCheckResourceAttrSet("data.stacklet_binding.by_name", "uuid"),
+				resource.TestCheckResourceAttr("data.stacklet_binding.by_name", "execution_config.variables", "{\"environment\":\"test\",\"region\":\"us-east-1\"}"),
 
 				// Verify lookup by UUID
 				resource.TestCheckResourceAttr("data.stacklet_binding.by_uuid", "name", prefixName("binding-ds")),
@@ -69,6 +72,7 @@ func TestAccBindingDataSource(t *testing.T) {
 				resource.TestCheckResourceAttr("data.stacklet_binding.by_uuid", "schedule", "rate(1 hour)"),
 				resource.TestCheckResourceAttrSet("data.stacklet_binding.by_uuid", "id"),
 				resource.TestCheckResourceAttrSet("data.stacklet_binding.by_uuid", "uuid"),
+				resource.TestCheckResourceAttr("data.stacklet_binding.by_uuid", "execution_config.variables", "{\"environment\":\"test\",\"region\":\"us-east-1\"}"),
 			),
 		},
 	}

--- a/internal/acceptance_tests/binding_resource_test.go
+++ b/internal/acceptance_tests/binding_resource_test.go
@@ -33,10 +33,12 @@ func TestAccBindingResource(t *testing.T) {
 						policy_collection_uuid = stacklet_policy_collection.test.uuid
 						auto_deploy = true
 						schedule = "rate(1 hour)"
-						variables = jsonencode({
-							environment = "test"
-							region = "us-east-1"
-						})
+						execution_config = {
+							variables = jsonencode({
+								environment = "test"
+								region = "us-east-1"
+							})
+						}
 					}
 				`,
 			Check: resource.ComposeAggregateTestCheckFunc(
@@ -48,6 +50,7 @@ func TestAccBindingResource(t *testing.T) {
 				resource.TestCheckResourceAttr("stacklet_binding.test", "schedule", "rate(1 hour)"),
 				resource.TestCheckResourceAttrSet("stacklet_binding.test", "id"),
 				resource.TestCheckResourceAttrSet("stacklet_binding.test", "uuid"),
+				resource.TestCheckResourceAttr("stacklet_binding.test", "execution_config.variables", "{\"environment\":\"test\",\"region\":\"us-east-1\"}"),
 			),
 		},
 		// ImportState testing
@@ -80,10 +83,12 @@ func TestAccBindingResource(t *testing.T) {
 						policy_collection_uuid = stacklet_policy_collection.test.uuid
 						auto_deploy = false
 						schedule = "rate(2 hours)"
-						variables = jsonencode({
-							environment = "staging"
-							region = "us-west-2"
-						})
+						execution_config = {
+							variables = jsonencode({
+								environment = "staging"
+								region = "us-west-2"
+							})
+						}
 					}
 				`,
 			Check: resource.ComposeAggregateTestCheckFunc(
@@ -95,6 +100,7 @@ func TestAccBindingResource(t *testing.T) {
 				resource.TestCheckResourceAttr("stacklet_binding.test", "schedule", "rate(2 hours)"),
 				resource.TestCheckResourceAttrSet("stacklet_binding.test", "id"),
 				resource.TestCheckResourceAttrSet("stacklet_binding.test", "uuid"),
+				resource.TestCheckResourceAttr("stacklet_binding.test", "execution_config.variables", "{\"environment\":\"staging\",\"region\":\"us-west-2\"}"),
 			),
 		},
 	}

--- a/internal/api/binding.go
+++ b/internal/api/binding.go
@@ -22,10 +22,8 @@ type Binding struct {
 	PolicyCollection struct {
 		UUID string
 	}
-	ExecutionConfig struct {
-		Variables *string
-	}
-	System bool
+	ExecutionConfig *BindingExecutionConfig
+	System          bool
 }
 
 // ExecutionConfig holds the execution configuration for a binding.
@@ -35,14 +33,14 @@ type BindingExecutionConfig struct {
 
 // BindingCreateInput is the input for creating a binding.
 type BindingCreateInput struct {
-	Name                 string                 `json:"name"`
-	Description          *string                `json:"description,omitempty"`
-	AutoDeploy           bool                   `json:"autoDeploy"`
-	Schedule             *string                `json:"schedule,omitempty"`
-	ExecutionConfig      BindingExecutionConfig `json:"executionConfig,omitempty"`
-	AccountGroupUUID     string                 `json:"accountGroupUUID"`
-	PolicyCollectionUUID string                 `json:"policyCollectionUUID"`
-	Deploy               bool                   `json:"deploy"`
+	Name                 string                  `json:"name"`
+	Description          *string                 `json:"description,omitempty"`
+	AutoDeploy           bool                    `json:"autoDeploy"`
+	Schedule             *string                 `json:"schedule,omitempty"`
+	ExecutionConfig      *BindingExecutionConfig `json:"executionConfig,omitempty"`
+	AccountGroupUUID     string                  `json:"accountGroupUUID"`
+	PolicyCollectionUUID string                  `json:"policyCollectionUUID"`
+	Deploy               bool                    `json:"deploy"`
 }
 
 func (i BindingCreateInput) GetGraphQLType() string {
@@ -50,12 +48,12 @@ func (i BindingCreateInput) GetGraphQLType() string {
 }
 
 type BindingUpdateInput struct {
-	UUID            string                 `json:"uuid"`
-	Name            string                 `json:"name"`
-	Description     *string                `json:"description"`
-	AutoDeploy      bool                   `json:"autoDeploy"`
-	Schedule        *string                `json:"schedule"`
-	ExecutionConfig BindingExecutionConfig `json:"executionConfig"`
+	UUID            string                  `json:"uuid"`
+	Name            string                  `json:"name"`
+	Description     *string                 `json:"description"`
+	AutoDeploy      bool                    `json:"autoDeploy"`
+	Schedule        *string                 `json:"schedule"`
+	ExecutionConfig *BindingExecutionConfig `json:"executionConfig,omitempty"`
 }
 
 func (i BindingUpdateInput) GetGraphQLType() string {

--- a/internal/datasources/policy_collection.go
+++ b/internal/datasources/policy_collection.go
@@ -133,8 +133,8 @@ func (d *policyCollectionDataSource) Read(ctx context.Context, req datasource.Re
 	dynamicConfig, diags := tftypes.ObjectValue(
 		ctx,
 		policyCollection.RepositoryView,
-		func() (models.PolicyCollectionDynamicConfig, error) {
-			return models.PolicyCollectionDynamicConfig{
+		func() (*models.PolicyCollectionDynamicConfig, error) {
+			return &models.PolicyCollectionDynamicConfig{
 				RepositoryUUID:     types.StringValue(*policyCollection.RepositoryConfig.UUID),
 				Namespace:          types.StringValue(policyCollection.RepositoryView.Namespace),
 				BranchName:         types.StringValue(policyCollection.RepositoryView.BranchName),

--- a/internal/models/binding.go
+++ b/internal/models/binding.go
@@ -3,9 +3,11 @@
 package models
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// BindingResource is the model for a binding resource.
 type BindingResource struct {
 	ID                   types.String `tfsdk:"id"`
 	UUID                 types.String `tfsdk:"uuid"`
@@ -13,21 +15,22 @@ type BindingResource struct {
 	Description          types.String `tfsdk:"description"`
 	AutoDeploy           types.Bool   `tfsdk:"auto_deploy"`
 	Schedule             types.String `tfsdk:"schedule"`
-	Variables            types.String `tfsdk:"variables"`
 	AccountGroupUUID     types.String `tfsdk:"account_group_uuid"`
 	PolicyCollectionUUID types.String `tfsdk:"policy_collection_uuid"`
 	System               types.Bool   `tfsdk:"system"`
+	ExecutionConfig      types.Object `tfsdk:"execution_config"`
 }
 
-type BindingDataSource struct {
-	ID                   types.String `tfsdk:"id"`
-	UUID                 types.String `tfsdk:"uuid"`
-	Name                 types.String `tfsdk:"name"`
-	Description          types.String `tfsdk:"description"`
-	AutoDeploy           types.Bool   `tfsdk:"auto_deploy"`
-	Schedule             types.String `tfsdk:"schedule"`
-	Variables            types.String `tfsdk:"variables"`
-	AccountGroupUUID     types.String `tfsdk:"account_group_uuid"`
-	PolicyCollectionUUID types.String `tfsdk:"policy_collection_uuid"`
-	System               types.Bool   `tfsdk:"system"`
+// BindingDataSource is the model for a binding data source.
+type BindingDataSource BindingResource
+
+// BindingExecutionConfig is the model for the execution config for a binding.
+type BindingExecutionConfig struct {
+	Variables types.String `tfsdk:"variables"`
+}
+
+func (c BindingExecutionConfig) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"variables": types.StringType,
+	}
 }

--- a/internal/resources/policy_collection.go
+++ b/internal/resources/policy_collection.go
@@ -288,8 +288,8 @@ func (r policyCollectionResource) updatePolicyCollectionModel(ctx context.Contex
 	dynamicConfig, diags := tftypes.ObjectValue(
 		ctx,
 		policyCollection.RepositoryView,
-		func() (models.PolicyCollectionDynamicConfig, error) {
-			return models.PolicyCollectionDynamicConfig{
+		func() (*models.PolicyCollectionDynamicConfig, error) {
+			return &models.PolicyCollectionDynamicConfig{
 				RepositoryUUID:     types.StringValue(*policyCollection.RepositoryConfig.UUID),
 				Namespace:          types.StringValue(policyCollection.RepositoryView.Namespace),
 				BranchName:         types.StringValue(policyCollection.RepositoryView.BranchName),

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -52,17 +52,20 @@ type WithAttributes interface {
 }
 
 // ObjectValue reutrns a basetypes.ObjectVvalue from a type.
-func ObjectValue[Type WithAttributes, Value any](ctx context.Context, v *Value, construct func() (Type, error)) (basetypes.ObjectValue, diag.Diagnostics) {
+func ObjectValue[Type WithAttributes, Value any](ctx context.Context, v *Value, construct func() (*Type, error)) (basetypes.ObjectValue, diag.Diagnostics) {
 	var empty Type
 	var diags diag.Diagnostics
 	attrTypes := empty.AttributeTypes()
 	if v == nil {
 		return basetypes.NewObjectNull(attrTypes), diags
 	}
-	obj, err := construct()
+	objPtr, err := construct()
 	if err != nil {
 		diags.AddError("Object conversion error", err.Error())
 		return basetypes.NewObjectNull(attrTypes), diags
 	}
-	return basetypes.NewObjectValueFrom(ctx, attrTypes, obj)
+	if objPtr == nil {
+		return basetypes.NewObjectNull(attrTypes), diags
+	}
+	return basetypes.NewObjectValueFrom(ctx, attrTypes, *objPtr)
 }

--- a/justfile
+++ b/justfile
@@ -2,13 +2,18 @@ package := "./internal/..."
 
 # Build the provider
 build:
-    go mod download
     go build -o terraform-provider-stacklet
 
 # Format code
-format:
+format: format-go format-tf
+
+# Format terraform code
+format-tf:
     terraform fmt -recursive
-    go fmt ./...
+
+# Format golang code
+format-go:
+    go fmt ./...    
 
 # Run linters
 lint: lint-go lint-tf lint-copyright


### PR DESCRIPTION
### what

move the `variables` attribute for bindings under `execution_config`. This
config will grow additional attributes in followup branches

### why

collect all config related to execution under a single attribute

### testing

tested in sandbox

### docs

updated here
