### PR TITLE
chore: return diag.Diagnostics instead of an error in ObjectValue construct

### DIFF
--- a/internal/datasources/binding.go
+++ b/internal/datasources/binding.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/stacklet/terraform-provider-stacklet/internal/api"
@@ -132,17 +133,19 @@ func (d *bindingDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	executionConfig, diags := tftypes.ObjectValue(
 		ctx,
 		&binding.ExecutionConfig,
-		func() (*models.BindingDataSourceExecutionConfig, error) {
+		func() (*models.BindingDataSourceExecutionConfig, diag.Diagnostics) {
+			var diags diag.Diagnostics
 			variablesString, err := tftypes.JSONString(binding.ExecutionConfig.Variables)
 			if err != nil {
-				return nil, err
+				errors.AddDiagError(&diags, err)
+				return nil, diags
 			}
 
 			return &models.BindingDataSourceExecutionConfig{
 				DryRun:          types.BoolValue(binding.ExecutionConfig.DryRunDefault()),
 				SecurityContext: tftypes.NullableString(binding.ExecutionConfig.SecurityContextDefault()),
 				Variables:       variablesString,
-			}, nil
+			}, diags
 		},
 	)
 	data.ExecutionConfig = executionConfig

--- a/internal/datasources/policy_collection.go
+++ b/internal/datasources/policy_collection.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/stacklet/terraform-provider-stacklet/internal/api"
@@ -133,7 +134,7 @@ func (d *policyCollectionDataSource) Read(ctx context.Context, req datasource.Re
 	dynamicConfig, diags := tftypes.ObjectValue(
 		ctx,
 		policyCollection.RepositoryView,
-		func() (*models.PolicyCollectionDynamicConfig, error) {
+		func() (*models.PolicyCollectionDynamicConfig, diag.Diagnostics) {
 			return &models.PolicyCollectionDynamicConfig{
 				RepositoryUUID:     types.StringValue(*policyCollection.RepositoryConfig.UUID),
 				Namespace:          types.StringValue(policyCollection.RepositoryView.Namespace),

--- a/internal/resources/policy_collection.go
+++ b/internal/resources/policy_collection.go
@@ -288,7 +288,7 @@ func (r policyCollectionResource) updatePolicyCollectionModel(ctx context.Contex
 	dynamicConfig, diags := tftypes.ObjectValue(
 		ctx,
 		policyCollection.RepositoryView,
-		func() (*models.PolicyCollectionDynamicConfig, error) {
+		func() (*models.PolicyCollectionDynamicConfig, diag.Diagnostics) {
 			return &models.PolicyCollectionDynamicConfig{
 				RepositoryUUID:     types.StringValue(*policyCollection.RepositoryConfig.UUID),
 				Namespace:          types.StringValue(policyCollection.RepositoryView.Namespace),

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -52,15 +52,15 @@ type WithAttributes interface {
 }
 
 // ObjectValue returns a basetypes.ObjectValue from a type.
-func ObjectValue[Type WithAttributes, Value any](ctx context.Context, v *Value, construct func() (*Type, error)) (basetypes.ObjectValue, diag.Diagnostics) {
+func ObjectValue[Type WithAttributes, Value any](ctx context.Context, v *Value, construct func() (*Type, diag.Diagnostics)) (basetypes.ObjectValue, diag.Diagnostics) {
 	var empty Type
 	var diags diag.Diagnostics
 	if v == nil {
 		return NullObject(empty), diags
 	}
-	objPtr, err := construct()
-	if err != nil {
-		diags.AddError("Object conversion error", err.Error())
+	objPtr, d := construct()
+	diags.Append(d...)
+	if diags.HasError() {
 		return NullObject(empty), diags
 	}
 	if objPtr == nil {


### PR DESCRIPTION
### what

return diag.Diagnostics instead of a plain error in the construct function
passed to ObjectValue

### why

makes it easier to propagate errors

### testing

acceptance tests

### docs

n/a
