### PR TITLE
feat: return an attribute-specific error for invalid "variables" content

### DIFF
--- a/internal/datasources/account.go
+++ b/internal/datasources/account.go
@@ -112,7 +112,7 @@ func (d *accountDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	data.SecurityContext = tftypes.NullableString(account.SecurityContext)
 	variablesString, err := tftypes.JSONString(account.Variables)
 	if err != nil {
-		resp.Diagnostics.AddError("Invalid content for variables", err.Error())
+		errors.AddDiagAttributeError(&resp.Diagnostics, "variables", err)
 		return
 	}
 	data.Variables = variablesString

--- a/internal/datasources/binding.go
+++ b/internal/datasources/binding.go
@@ -149,7 +149,7 @@ func (d *bindingDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	variablesString, err := tftypes.JSONString(binding.ExecutionConfig.Variables)
 	if err != nil {
-		resp.Diagnostics.AddError("Invalid content for variables", err.Error())
+		errors.AddDiagAttributeError(&resp.Diagnostics, "variables", err)
 		return
 	}
 	data.Variables = variablesString

--- a/internal/resources/account.go
+++ b/internal/resources/account.go
@@ -144,7 +144,7 @@ func (r *accountResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	resp.Diagnostics.Append(r.updateAccountModel(&plan, account))
+	resp.Diagnostics.Append(r.updateAccountModel(&plan, account)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -164,7 +164,7 @@ func (r *accountResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	resp.Diagnostics.Append(r.updateAccountModel(&state, account))
+	resp.Diagnostics.Append(r.updateAccountModel(&state, account)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -202,7 +202,7 @@ func (r *accountResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	resp.Diagnostics.Append(r.updateAccountModel(&plan, account))
+	resp.Diagnostics.Append(r.updateAccountModel(&plan, account)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -233,7 +233,8 @@ func (r *accountResource) ImportState(ctx context.Context, req resource.ImportSt
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("key"), parts[1])...)
 }
 
-func (r accountResource) updateAccountModel(m *models.AccountResource, account *api.Account) diag.Diagnostic {
+func (r accountResource) updateAccountModel(m *models.AccountResource, account *api.Account) diag.Diagnostics {
+	var diags diag.Diagnostics
 	m.ID = types.StringValue(account.ID)
 	m.Key = types.StringValue(account.Key)
 	m.Name = types.StringValue(account.Name)
@@ -245,8 +246,9 @@ func (r accountResource) updateAccountModel(m *models.AccountResource, account *
 	m.SecurityContext = tftypes.NullableString(account.SecurityContext)
 	variablesString, err := tftypes.JSONString(account.Variables)
 	if err != nil {
-		return diag.NewErrorDiagnostic("Invalid content for variables", err.Error())
+		errors.AddDiagAttributeError(&diags, "variables", err)
+		return diags
 	}
 	m.Variables = variablesString
-	return nil
+	return diags
 }

--- a/internal/resources/binding.go
+++ b/internal/resources/binding.go
@@ -282,7 +282,7 @@ func (r bindingResource) updateBindingModel(ctx context.Context, m *models.Bindi
 
 	variablesString, err := tftypes.JSONString(binding.ExecutionConfig.Variables)
 	if err != nil {
-		diags.Append(diag.NewErrorDiagnostic("Invalid content for variables", err.Error()))
+		errors.AddDiagAttributeError(&diags, "variables", err)
 		return diags
 	}
 	// the API returns an empty dict for null or empty string, don't


### PR DESCRIPTION
### what

when the content of the "variables" attribute (for account and bindings) is
invalid, return an attribute-specific error

### why

make it clearer where the error comes from

### testing

n/a

### docs

n/a
