### PR TITLE
feat: validate "recipient" field in report group resource

### DIFF
--- a/internal/resources/report_group.go
+++ b/internal/resources/report_group.go
@@ -143,7 +143,7 @@ func (r *reportGroupResource) Schema(_ context.Context, _ resource.SchemaRequest
 									},
 								},
 								Validators: []validator.Object{
-									schemavalidate.ExactlyOneRecipient(),
+									schemavalidate.ValidRecipient(),
 								},
 							},
 						},
@@ -193,7 +193,7 @@ func (r *reportGroupResource) Schema(_ context.Context, _ resource.SchemaRequest
 									},
 								},
 								Validators: []validator.Object{
-									schemavalidate.ExactlyOneRecipient(),
+									schemavalidate.ValidRecipient(),
 								},
 							},
 						},
@@ -239,7 +239,7 @@ func (r *reportGroupResource) Schema(_ context.Context, _ resource.SchemaRequest
 									},
 								},
 								Validators: []validator.Object{
-									schemavalidate.ExactlyOneRecipient(),
+									schemavalidate.ValidRecipient(),
 								},
 							},
 						},
@@ -285,7 +285,7 @@ func (r *reportGroupResource) Schema(_ context.Context, _ resource.SchemaRequest
 									},
 								},
 								Validators: []validator.Object{
-									schemavalidate.ExactlyOneRecipient(),
+									schemavalidate.ValidRecipient(),
 								},
 							},
 						},
@@ -343,7 +343,7 @@ func (r *reportGroupResource) Schema(_ context.Context, _ resource.SchemaRequest
 									},
 								},
 								Validators: []validator.Object{
-									schemavalidate.ExactlyOneRecipient(),
+									schemavalidate.ValidRecipient(),
 								},
 							},
 						},
@@ -401,7 +401,7 @@ func (r *reportGroupResource) Schema(_ context.Context, _ resource.SchemaRequest
 									},
 								},
 								Validators: []validator.Object{
-									schemavalidate.ExactlyOneRecipient(),
+									schemavalidate.ValidRecipient(),
 								},
 							},
 						},

--- a/internal/schemavalidate/valid_recipient.go
+++ b/internal/schemavalidate/valid_recipient.go
@@ -9,10 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// ExactlyOneRecipient returns a validator that ensures that exactly one field
-// is set in for recipients: either one of the owners flags are true, or
-// exactly one of tag and value is set.
-func ExactlyOneRecipient() validator.Object {
+// ValidRecipient returns a validator that ensures that exactly one field is
+// set in for recipients: either one of the owners flags are true, or exactly
+// one of tag and value is set.
+func ValidRecipient() validator.Object {
 	return exactlyOneRecipient{}
 }
 


### PR DESCRIPTION
### what

Ensure only one of the recipient fields is set in report group delivery settings.

### why

The API only allows setting one, validating provider-side avoids failures from the API
which are harder to debug

### testing

manual testing with sample configuration

### docs

n/a
