### PR TITLE
feat: support delivery settings for all transports for resource groups [ENG-5559]

### DIFF
--- a/internal/acceptance_tests/recordings/TestAccReportGroupDataSource.json
+++ b/internal/acceptance_tests/recordings/TestAccReportGroupDataSource.json
@@ -19,26 +19,26 @@
           "addAccountGroup": {
             "group": {
               "description": "Test account group for report group",
-              "id": "WyJhY2NvdW50LWdyb3VwIiwgIjAzMjcyZDJlLWMwMjQtNGQ2Yi05ZjY0LTkyMjU5MGNjNmExZCJd",
+              "id": "WyJhY2NvdW50LWdyb3VwIiwgImMyNGExOGY5LTU2YTMtNDk2Mi1iZDNmLTZkMzUxMzhmYTY3MSJd",
               "name": "test-rg-ag",
               "provider": "AWS",
               "regions": [
                 "us-east-1"
               ],
-              "uuid": "03272d2e-c024-4d6b-9f64-922590cc6a1d"
+              "uuid": "c24a18f9-56a3-4962-bd3f-6d35138fa671"
             }
           }
         }
       }
     }
   ],
-  "mutation ($input:AddBindingInput!){addBinding(input: $input){binding{id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}}:{\"input\":{\"accountGroupUUID\":\"03272d2e-c024-4d6b-9f64-922590cc6a1d\",\"autoDeploy\":true,\"deploy\":true,\"description\":\"Test binding for report group\",\"executionConfig\":{\"dryRun\":null,\"resourceLimits\":{\"default\":null,\"policyOverrides\":[]},\"securityContext\":null,\"variables\":null},\"name\":\"test-rg-binding\",\"policyCollectionUUID\":\"5ea924c2-f0bb-475f-abfd-cbdcff5f7033\"}}": [
+  "mutation ($input:AddBindingInput!){addBinding(input: $input){binding{id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}}:{\"input\":{\"accountGroupUUID\":\"c24a18f9-56a3-4962-bd3f-6d35138fa671\",\"autoDeploy\":true,\"deploy\":true,\"description\":\"Test binding for report group\",\"executionConfig\":{\"dryRun\":null,\"resourceLimits\":{\"default\":null,\"policyOverrides\":[]},\"securityContext\":null,\"variables\":null},\"name\":\"test-rg-binding\",\"policyCollectionUUID\":\"c8c7efec-74d9-4375-a5e7-fdbfdc291248\"}}": [
     {
       "request": {
         "query": "mutation ($input:AddBindingInput!){addBinding(input: $input){binding{id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}}",
         "variables": {
           "input": {
-            "accountGroupUUID": "03272d2e-c024-4d6b-9f64-922590cc6a1d",
+            "accountGroupUUID": "c24a18f9-56a3-4962-bd3f-6d35138fa671",
             "autoDeploy": true,
             "deploy": true,
             "description": "Test binding for report group",
@@ -52,7 +52,7 @@
               "variables": null
             },
             "name": "test-rg-binding",
-            "policyCollectionUUID": "5ea924c2-f0bb-475f-abfd-cbdcff5f7033"
+            "policyCollectionUUID": "c8c7efec-74d9-4375-a5e7-fdbfdc291248"
           }
         }
       },
@@ -61,7 +61,7 @@
           "addBinding": {
             "binding": {
               "accountGroup": {
-                "uuid": "03272d2e-c024-4d6b-9f64-922590cc6a1d"
+                "uuid": "c24a18f9-56a3-4962-bd3f-6d35138fa671"
               },
               "autoDeploy": true,
               "description": "Test binding for report group",
@@ -71,14 +71,14 @@
                 "securityContext": null,
                 "variables": null
               },
-              "id": "WyJiaW5kaW5nIiwgIjI5ZmY1ZGMyLTVhNzctNDVjOC1iMTk1LTZkM2RkNGE5NjJlNSJd",
+              "id": "WyJiaW5kaW5nIiwgIjU1ODQxODMyLWFkZDYtNDYzMC1hYzI2LWVjOWU3NDNmMmFlNiJd",
               "name": "test-rg-binding",
               "policyCollection": {
-                "uuid": "5ea924c2-f0bb-475f-abfd-cbdcff5f7033"
+                "uuid": "c8c7efec-74d9-4375-a5e7-fdbfdc291248"
               },
               "schedule": null,
               "system": false,
-              "uuid": "29ff5dc2-5a77-45c8-b195-6d3dd4a962e5"
+              "uuid": "55841832-add6-4630-ac26-ec9e743f2ae6"
             }
           }
         }
@@ -104,21 +104,21 @@
             "collection": {
               "autoUpdate": false,
               "description": "Test policy collection for report group",
-              "id": "WyJwb2xpY3ktY29sbGVjdGlvbiIsICI1ZWE5MjRjMi1mMGJiLTQ3NWYtYWJmZC1jYmRjZmY1ZjcwMzMiXQ==",
+              "id": "WyJwb2xpY3ktY29sbGVjdGlvbiIsICJjOGM3ZWZlYy03NGQ5LTQzNzUtYTVlNy1mZGJmZGMyOTEyNDgiXQ==",
               "isDynamic": false,
               "name": "test-rg-pc",
               "provider": "AWS",
               "repositoryConfig": null,
               "repositoryView": null,
               "system": false,
-              "uuid": "5ea924c2-f0bb-475f-abfd-cbdcff5f7033"
+              "uuid": "c8c7efec-74d9-4375-a5e7-fdbfdc291248"
             }
           }
         }
       }
     }
   ],
-  "mutation ($input:UpsertReportGroupsInput!){upsertReportGroups(input: $input){reportGroups{id,name,enabled,bindings,source,schedule,groupBy,useMessageSettings,deliverySettings{__typename,... on EmailSettings{cc,firstMatchOnly,format,fromEmail,priority,recipients{account_owner,event_owner,resource_owner,tag,value},subject,template},... on SlackSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on TeamsSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on ServiceNowSettings{firstMatchOnly,impact,recipients{account_owner,event_owner,resource_owner,tag,value},shortDescription,template,urgency},... on JiraSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template,description,project,summary},... on SymphonySettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template}}}}}:{\"input\":{\"reportGroups\":[{\"bindings\":[\"29ff5dc2-5a77-45c8-b195-6d3dd4a962e5\"],\"emailSettings\":null,\"enabled\":true,\"groupBy\":[\"account\",\"region\"],\"name\":\"test-report-group\",\"schedule\":\"0 12 * * *\",\"source\":\"BINDING\",\"useMessageSettings\":true}]}}": [
+  "mutation ($input:UpsertReportGroupsInput!){upsertReportGroups(input: $input){reportGroups{id,name,enabled,bindings,source,schedule,groupBy,useMessageSettings,deliverySettings{__typename,... on EmailSettings{cc,firstMatchOnly,format,fromEmail,priority,recipients{account_owner,event_owner,resource_owner,tag,value},subject,template},... on SlackSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on TeamsSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on ServiceNowSettings{firstMatchOnly,impact,recipients{account_owner,event_owner,resource_owner,tag,value},shortDescription,template,urgency},... on JiraSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template,description,project,summary},... on SymphonySettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template}}}}}:{\"input\":{\"reportGroups\":[{\"bindings\":[\"55841832-add6-4630-ac26-ec9e743f2ae6\"],\"emailSettings\":[{\"cc\":[],\"firstMatchOnly\":false,\"format\":\"\",\"fromEmail\":null,\"priority\":\"3\",\"recipients\":[{\"account_owner\":null,\"event_owner\":null,\"resource_owner\":true,\"tag\":null,\"value\":null},{\"account_owner\":null,\"event_owner\":null,\"resource_owner\":null,\"tag\":null,\"value\":\"user@example.com\"}],\"subject\":\"Matched resources\",\"template\":\"email\"}],\"enabled\":true,\"groupBy\":[\"account\",\"region\"],\"jiraSettings\":null,\"name\":\"test-report-group\",\"schedule\":\"0 12 * * *\",\"serviceNowSettings\":null,\"slackSettings\":null,\"source\":\"BINDING\",\"symphonySettings\":null,\"teamsSettings\":null,\"useMessageSettings\":true}]}}": [
     {
       "request": {
         "query": "mutation ($input:UpsertReportGroupsInput!){upsertReportGroups(input: $input){reportGroups{id,name,enabled,bindings,source,schedule,groupBy,useMessageSettings,deliverySettings{__typename,... on EmailSettings{cc,firstMatchOnly,format,fromEmail,priority,recipients{account_owner,event_owner,resource_owner,tag,value},subject,template},... on SlackSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on TeamsSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on ServiceNowSettings{firstMatchOnly,impact,recipients{account_owner,event_owner,resource_owner,tag,value},shortDescription,template,urgency},... on JiraSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template,description,project,summary},... on SymphonySettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template}}}}}",
@@ -127,17 +127,48 @@
             "reportGroups": [
               {
                 "bindings": [
-                  "29ff5dc2-5a77-45c8-b195-6d3dd4a962e5"
+                  "55841832-add6-4630-ac26-ec9e743f2ae6"
                 ],
-                "emailSettings": null,
+                "emailSettings": [
+                  {
+                    "cc": [],
+                    "firstMatchOnly": false,
+                    "format": "",
+                    "fromEmail": null,
+                    "priority": "3",
+                    "recipients": [
+                      {
+                        "account_owner": null,
+                        "event_owner": null,
+                        "resource_owner": true,
+                        "tag": null,
+                        "value": null
+                      },
+                      {
+                        "account_owner": null,
+                        "event_owner": null,
+                        "resource_owner": null,
+                        "tag": null,
+                        "value": "user@example.com"
+                      }
+                    ],
+                    "subject": "Matched resources",
+                    "template": "email"
+                  }
+                ],
                 "enabled": true,
                 "groupBy": [
                   "account",
                   "region"
                 ],
+                "jiraSettings": null,
                 "name": "test-report-group",
                 "schedule": "0 12 * * *",
+                "serviceNowSettings": null,
+                "slackSettings": null,
                 "source": "BINDING",
+                "symphonySettings": null,
+                "teamsSettings": null,
                 "useMessageSettings": true
               }
             ]
@@ -150,9 +181,36 @@
             "reportGroups": [
               {
                 "bindings": [
-                  "29ff5dc2-5a77-45c8-b195-6d3dd4a962e5"
+                  "55841832-add6-4630-ac26-ec9e743f2ae6"
                 ],
-                "deliverySettings": [],
+                "deliverySettings": [
+                  {
+                    "__typename": "EmailSettings",
+                    "cc": [],
+                    "firstMatchOnly": false,
+                    "format": "",
+                    "fromEmail": null,
+                    "priority": "3",
+                    "recipients": [
+                      {
+                        "account_owner": null,
+                        "event_owner": null,
+                        "resource_owner": true,
+                        "tag": null,
+                        "value": null
+                      },
+                      {
+                        "account_owner": null,
+                        "event_owner": null,
+                        "resource_owner": null,
+                        "tag": null,
+                        "value": "user@example.com"
+                      }
+                    ],
+                    "subject": "Matched resources",
+                    "template": "email"
+                  }
+                ],
                 "enabled": true,
                 "groupBy": [
                   "account",
@@ -189,102 +247,102 @@
       }
     }
   ],
-  "mutation ($uuid:String!){removeAccountGroup(uuid: $uuid){group{uuid}}}:{\"uuid\":\"03272d2e-c024-4d6b-9f64-922590cc6a1d\"}": [
+  "mutation ($uuid:String!){removeAccountGroup(uuid: $uuid){group{uuid}}}:{\"uuid\":\"c24a18f9-56a3-4962-bd3f-6d35138fa671\"}": [
     {
       "request": {
         "query": "mutation ($uuid:String!){removeAccountGroup(uuid: $uuid){group{uuid}}}",
         "variables": {
-          "uuid": "03272d2e-c024-4d6b-9f64-922590cc6a1d"
+          "uuid": "c24a18f9-56a3-4962-bd3f-6d35138fa671"
         }
       },
       "response": {
         "data": {
           "removeAccountGroup": {
             "group": {
-              "uuid": "03272d2e-c024-4d6b-9f64-922590cc6a1d"
+              "uuid": "c24a18f9-56a3-4962-bd3f-6d35138fa671"
             }
           }
         }
       }
     }
   ],
-  "mutation ($uuid:String!){removeBinding(uuid: $uuid){binding{uuid}}}:{\"uuid\":\"29ff5dc2-5a77-45c8-b195-6d3dd4a962e5\"}": [
+  "mutation ($uuid:String!){removeBinding(uuid: $uuid){binding{uuid}}}:{\"uuid\":\"55841832-add6-4630-ac26-ec9e743f2ae6\"}": [
     {
       "request": {
         "query": "mutation ($uuid:String!){removeBinding(uuid: $uuid){binding{uuid}}}",
         "variables": {
-          "uuid": "29ff5dc2-5a77-45c8-b195-6d3dd4a962e5"
+          "uuid": "55841832-add6-4630-ac26-ec9e743f2ae6"
         }
       },
       "response": {
         "data": {
           "removeBinding": {
             "binding": {
-              "uuid": "29ff5dc2-5a77-45c8-b195-6d3dd4a962e5"
+              "uuid": "55841832-add6-4630-ac26-ec9e743f2ae6"
             }
           }
         }
       }
     }
   ],
-  "mutation ($uuid:String!){removePolicyCollection(uuid: $uuid){collection{uuid}}}:{\"uuid\":\"5ea924c2-f0bb-475f-abfd-cbdcff5f7033\"}": [
+  "mutation ($uuid:String!){removePolicyCollection(uuid: $uuid){collection{uuid}}}:{\"uuid\":\"c8c7efec-74d9-4375-a5e7-fdbfdc291248\"}": [
     {
       "request": {
         "query": "mutation ($uuid:String!){removePolicyCollection(uuid: $uuid){collection{uuid}}}",
         "variables": {
-          "uuid": "5ea924c2-f0bb-475f-abfd-cbdcff5f7033"
+          "uuid": "c8c7efec-74d9-4375-a5e7-fdbfdc291248"
         }
       },
       "response": {
         "data": {
           "removePolicyCollection": {
             "collection": {
-              "uuid": "5ea924c2-f0bb-475f-abfd-cbdcff5f7033"
+              "uuid": "c8c7efec-74d9-4375-a5e7-fdbfdc291248"
             }
           }
         }
       }
     }
   ],
-  "query ($name:String!$uuid:String!){accountGroup(uuid: $uuid, name: $name){id,uuid,name,description,provider,regions}}:{\"name\":\"\",\"uuid\":\"03272d2e-c024-4d6b-9f64-922590cc6a1d\"}": [
+  "query ($name:String!$uuid:String!){accountGroup(uuid: $uuid, name: $name){id,uuid,name,description,provider,regions}}:{\"name\":\"\",\"uuid\":\"c24a18f9-56a3-4962-bd3f-6d35138fa671\"}": [
     {
       "request": {
         "query": "query ($name:String!$uuid:String!){accountGroup(uuid: $uuid, name: $name){id,uuid,name,description,provider,regions}}",
         "variables": {
           "name": "",
-          "uuid": "03272d2e-c024-4d6b-9f64-922590cc6a1d"
+          "uuid": "c24a18f9-56a3-4962-bd3f-6d35138fa671"
         }
       },
       "response": {
         "data": {
           "accountGroup": {
             "description": "Test account group for report group",
-            "id": "WyJhY2NvdW50LWdyb3VwIiwgIjAzMjcyZDJlLWMwMjQtNGQ2Yi05ZjY0LTkyMjU5MGNjNmExZCJd",
+            "id": "WyJhY2NvdW50LWdyb3VwIiwgImMyNGExOGY5LTU2YTMtNDk2Mi1iZDNmLTZkMzUxMzhmYTY3MSJd",
             "name": "test-rg-ag",
             "provider": "AWS",
             "regions": [
               "us-east-1"
             ],
-            "uuid": "03272d2e-c024-4d6b-9f64-922590cc6a1d"
+            "uuid": "c24a18f9-56a3-4962-bd3f-6d35138fa671"
           }
         }
       }
     }
   ],
-  "query ($name:String!$uuid:String!){binding(uuid: $uuid, name: $name){id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}:{\"name\":\"\",\"uuid\":\"29ff5dc2-5a77-45c8-b195-6d3dd4a962e5\"}": [
+  "query ($name:String!$uuid:String!){binding(uuid: $uuid, name: $name){id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}:{\"name\":\"\",\"uuid\":\"55841832-add6-4630-ac26-ec9e743f2ae6\"}": [
     {
       "request": {
         "query": "query ($name:String!$uuid:String!){binding(uuid: $uuid, name: $name){id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}",
         "variables": {
           "name": "",
-          "uuid": "29ff5dc2-5a77-45c8-b195-6d3dd4a962e5"
+          "uuid": "55841832-add6-4630-ac26-ec9e743f2ae6"
         }
       },
       "response": {
         "data": {
           "binding": {
             "accountGroup": {
-              "uuid": "03272d2e-c024-4d6b-9f64-922590cc6a1d"
+              "uuid": "c24a18f9-56a3-4962-bd3f-6d35138fa671"
             },
             "autoDeploy": true,
             "description": "Test binding for report group",
@@ -294,26 +352,26 @@
               "securityContext": null,
               "variables": null
             },
-            "id": "WyJiaW5kaW5nIiwgIjI5ZmY1ZGMyLTVhNzctNDVjOC1iMTk1LTZkM2RkNGE5NjJlNSJd",
+            "id": "WyJiaW5kaW5nIiwgIjU1ODQxODMyLWFkZDYtNDYzMC1hYzI2LWVjOWU3NDNmMmFlNiJd",
             "name": "test-rg-binding",
             "policyCollection": {
-              "uuid": "5ea924c2-f0bb-475f-abfd-cbdcff5f7033"
+              "uuid": "c8c7efec-74d9-4375-a5e7-fdbfdc291248"
             },
             "schedule": null,
             "system": false,
-            "uuid": "29ff5dc2-5a77-45c8-b195-6d3dd4a962e5"
+            "uuid": "55841832-add6-4630-ac26-ec9e743f2ae6"
           }
         }
       }
     }
   ],
-  "query ($name:String!$uuid:String!){policyCollection(uuid: $uuid, name: $name){id,uuid,name,description,provider,autoUpdate,system,isDynamic,repositoryConfig{uuid},repositoryView{namespace,branchName,policyDirectories,policyFileSuffix}}}:{\"name\":\"\",\"uuid\":\"5ea924c2-f0bb-475f-abfd-cbdcff5f7033\"}": [
+  "query ($name:String!$uuid:String!){policyCollection(uuid: $uuid, name: $name){id,uuid,name,description,provider,autoUpdate,system,isDynamic,repositoryConfig{uuid},repositoryView{namespace,branchName,policyDirectories,policyFileSuffix}}}:{\"name\":\"\",\"uuid\":\"c8c7efec-74d9-4375-a5e7-fdbfdc291248\"}": [
     {
       "request": {
         "query": "query ($name:String!$uuid:String!){policyCollection(uuid: $uuid, name: $name){id,uuid,name,description,provider,autoUpdate,system,isDynamic,repositoryConfig{uuid},repositoryView{namespace,branchName,policyDirectories,policyFileSuffix}}}",
         "variables": {
           "name": "",
-          "uuid": "5ea924c2-f0bb-475f-abfd-cbdcff5f7033"
+          "uuid": "c8c7efec-74d9-4375-a5e7-fdbfdc291248"
         }
       },
       "response": {
@@ -321,14 +379,14 @@
           "policyCollection": {
             "autoUpdate": false,
             "description": "Test policy collection for report group",
-            "id": "WyJwb2xpY3ktY29sbGVjdGlvbiIsICI1ZWE5MjRjMi1mMGJiLTQ3NWYtYWJmZC1jYmRjZmY1ZjcwMzMiXQ==",
+            "id": "WyJwb2xpY3ktY29sbGVjdGlvbiIsICJjOGM3ZWZlYy03NGQ5LTQzNzUtYTVlNy1mZGJmZGMyOTEyNDgiXQ==",
             "isDynamic": false,
             "name": "test-rg-pc",
             "provider": "AWS",
             "repositoryConfig": null,
             "repositoryView": null,
             "system": false,
-            "uuid": "5ea924c2-f0bb-475f-abfd-cbdcff5f7033"
+            "uuid": "c8c7efec-74d9-4375-a5e7-fdbfdc291248"
           }
         }
       }
@@ -346,9 +404,36 @@
         "data": {
           "reportGroup": {
             "bindings": [
-              "29ff5dc2-5a77-45c8-b195-6d3dd4a962e5"
+              "55841832-add6-4630-ac26-ec9e743f2ae6"
             ],
-            "deliverySettings": [],
+            "deliverySettings": [
+              {
+                "__typename": "EmailSettings",
+                "cc": [],
+                "firstMatchOnly": false,
+                "format": "",
+                "fromEmail": null,
+                "priority": "3",
+                "recipients": [
+                  {
+                    "account_owner": null,
+                    "event_owner": null,
+                    "resource_owner": true,
+                    "tag": null,
+                    "value": null
+                  },
+                  {
+                    "account_owner": null,
+                    "event_owner": null,
+                    "resource_owner": null,
+                    "tag": null,
+                    "value": "user@example.com"
+                  }
+                ],
+                "subject": "Matched resources",
+                "template": "email"
+              }
+            ],
             "enabled": true,
             "groupBy": [
               "account",
@@ -374,9 +459,36 @@
         "data": {
           "reportGroup": {
             "bindings": [
-              "29ff5dc2-5a77-45c8-b195-6d3dd4a962e5"
+              "55841832-add6-4630-ac26-ec9e743f2ae6"
             ],
-            "deliverySettings": [],
+            "deliverySettings": [
+              {
+                "__typename": "EmailSettings",
+                "cc": [],
+                "firstMatchOnly": false,
+                "format": "",
+                "fromEmail": null,
+                "priority": "3",
+                "recipients": [
+                  {
+                    "account_owner": null,
+                    "event_owner": null,
+                    "resource_owner": true,
+                    "tag": null,
+                    "value": null
+                  },
+                  {
+                    "account_owner": null,
+                    "event_owner": null,
+                    "resource_owner": null,
+                    "tag": null,
+                    "value": "user@example.com"
+                  }
+                ],
+                "subject": "Matched resources",
+                "template": "email"
+              }
+            ],
             "enabled": true,
             "groupBy": [
               "account",
@@ -402,9 +514,36 @@
         "data": {
           "reportGroup": {
             "bindings": [
-              "29ff5dc2-5a77-45c8-b195-6d3dd4a962e5"
+              "55841832-add6-4630-ac26-ec9e743f2ae6"
             ],
-            "deliverySettings": [],
+            "deliverySettings": [
+              {
+                "__typename": "EmailSettings",
+                "cc": [],
+                "firstMatchOnly": false,
+                "format": "",
+                "fromEmail": null,
+                "priority": "3",
+                "recipients": [
+                  {
+                    "account_owner": null,
+                    "event_owner": null,
+                    "resource_owner": true,
+                    "tag": null,
+                    "value": null
+                  },
+                  {
+                    "account_owner": null,
+                    "event_owner": null,
+                    "resource_owner": null,
+                    "tag": null,
+                    "value": "user@example.com"
+                  }
+                ],
+                "subject": "Matched resources",
+                "template": "email"
+              }
+            ],
             "enabled": true,
             "groupBy": [
               "account",
@@ -430,9 +569,36 @@
         "data": {
           "reportGroup": {
             "bindings": [
-              "29ff5dc2-5a77-45c8-b195-6d3dd4a962e5"
+              "55841832-add6-4630-ac26-ec9e743f2ae6"
             ],
-            "deliverySettings": [],
+            "deliverySettings": [
+              {
+                "__typename": "EmailSettings",
+                "cc": [],
+                "firstMatchOnly": false,
+                "format": "",
+                "fromEmail": null,
+                "priority": "3",
+                "recipients": [
+                  {
+                    "account_owner": null,
+                    "event_owner": null,
+                    "resource_owner": true,
+                    "tag": null,
+                    "value": null
+                  },
+                  {
+                    "account_owner": null,
+                    "event_owner": null,
+                    "resource_owner": null,
+                    "tag": null,
+                    "value": "user@example.com"
+                  }
+                ],
+                "subject": "Matched resources",
+                "template": "email"
+              }
+            ],
             "enabled": true,
             "groupBy": [
               "account",

--- a/internal/acceptance_tests/recordings/TestAccReportGroupResource.json
+++ b/internal/acceptance_tests/recordings/TestAccReportGroupResource.json
@@ -19,26 +19,26 @@
           "addAccountGroup": {
             "group": {
               "description": "Test account group for report group",
-              "id": "WyJhY2NvdW50LWdyb3VwIiwgImRmZTQ4OTcyLWFiZWYtNGUyOC04N2IwLTRiZmE0N2NiY2MyMyJd",
+              "id": "WyJhY2NvdW50LWdyb3VwIiwgIjVkNzgyZDg3LTk0MTEtNGZlNi04Yjg4LTMxNDBhMGJlMDQzOCJd",
               "name": "test-rg-ag",
               "provider": "AWS",
               "regions": [
                 "us-east-1"
               ],
-              "uuid": "dfe48972-abef-4e28-87b0-4bfa47cbcc23"
+              "uuid": "5d782d87-9411-4fe6-8b88-3140a0be0438"
             }
           }
         }
       }
     }
   ],
-  "mutation ($input:AddBindingInput!){addBinding(input: $input){binding{id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}}:{\"input\":{\"accountGroupUUID\":\"dfe48972-abef-4e28-87b0-4bfa47cbcc23\",\"autoDeploy\":true,\"deploy\":true,\"description\":\"Test binding for report group\",\"executionConfig\":{\"dryRun\":null,\"resourceLimits\":{\"default\":null,\"policyOverrides\":[]},\"securityContext\":null,\"variables\":null},\"name\":\"test-rg-binding\",\"policyCollectionUUID\":\"23d515cb-9b8d-45f4-8d9b-69756ba8eef2\"}}": [
+  "mutation ($input:AddBindingInput!){addBinding(input: $input){binding{id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}}:{\"input\":{\"accountGroupUUID\":\"5d782d87-9411-4fe6-8b88-3140a0be0438\",\"autoDeploy\":true,\"deploy\":true,\"description\":\"Test binding for report group\",\"executionConfig\":{\"dryRun\":null,\"resourceLimits\":{\"default\":null,\"policyOverrides\":[]},\"securityContext\":null,\"variables\":null},\"name\":\"test-rg-binding\",\"policyCollectionUUID\":\"a500e082-911e-41cd-834e-a53dee1fdffa\"}}": [
     {
       "request": {
         "query": "mutation ($input:AddBindingInput!){addBinding(input: $input){binding{id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}}",
         "variables": {
           "input": {
-            "accountGroupUUID": "dfe48972-abef-4e28-87b0-4bfa47cbcc23",
+            "accountGroupUUID": "5d782d87-9411-4fe6-8b88-3140a0be0438",
             "autoDeploy": true,
             "deploy": true,
             "description": "Test binding for report group",
@@ -52,7 +52,7 @@
               "variables": null
             },
             "name": "test-rg-binding",
-            "policyCollectionUUID": "23d515cb-9b8d-45f4-8d9b-69756ba8eef2"
+            "policyCollectionUUID": "a500e082-911e-41cd-834e-a53dee1fdffa"
           }
         }
       },
@@ -61,7 +61,7 @@
           "addBinding": {
             "binding": {
               "accountGroup": {
-                "uuid": "dfe48972-abef-4e28-87b0-4bfa47cbcc23"
+                "uuid": "5d782d87-9411-4fe6-8b88-3140a0be0438"
               },
               "autoDeploy": true,
               "description": "Test binding for report group",
@@ -71,14 +71,14 @@
                 "securityContext": null,
                 "variables": null
               },
-              "id": "WyJiaW5kaW5nIiwgIjgwMTZhZTk1LWVmYTUtNGRlMC1hOTZhLTYwM2NlY2ZjNTdmNCJd",
+              "id": "WyJiaW5kaW5nIiwgImE3ZTZhNWM1LTZlYzEtNGNjYy1hNWUwLWM1ZTQzZGY3NGNiZCJd",
               "name": "test-rg-binding",
               "policyCollection": {
-                "uuid": "23d515cb-9b8d-45f4-8d9b-69756ba8eef2"
+                "uuid": "a500e082-911e-41cd-834e-a53dee1fdffa"
               },
               "schedule": null,
               "system": false,
-              "uuid": "8016ae95-efa5-4de0-a96a-603cecfc57f4"
+              "uuid": "a7e6a5c5-6ec1-4ccc-a5e0-c5e43df74cbd"
             }
           }
         }
@@ -104,21 +104,21 @@
             "collection": {
               "autoUpdate": false,
               "description": "Test policy collection for report group",
-              "id": "WyJwb2xpY3ktY29sbGVjdGlvbiIsICIyM2Q1MTVjYi05YjhkLTQ1ZjQtOGQ5Yi02OTc1NmJhOGVlZjIiXQ==",
+              "id": "WyJwb2xpY3ktY29sbGVjdGlvbiIsICJhNTAwZTA4Mi05MTFlLTQxY2QtODM0ZS1hNTNkZWUxZmRmZmEiXQ==",
               "isDynamic": false,
               "name": "test-rg-pc",
               "provider": "AWS",
               "repositoryConfig": null,
               "repositoryView": null,
               "system": false,
-              "uuid": "23d515cb-9b8d-45f4-8d9b-69756ba8eef2"
+              "uuid": "a500e082-911e-41cd-834e-a53dee1fdffa"
             }
           }
         }
       }
     }
   ],
-  "mutation ($input:UpsertReportGroupsInput!){upsertReportGroups(input: $input){reportGroups{id,name,enabled,bindings,source,schedule,groupBy,useMessageSettings,deliverySettings{__typename,... on EmailSettings{cc,firstMatchOnly,format,fromEmail,priority,recipients{account_owner,event_owner,resource_owner,tag,value},subject,template},... on SlackSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on TeamsSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on ServiceNowSettings{firstMatchOnly,impact,recipients{account_owner,event_owner,resource_owner,tag,value},shortDescription,template,urgency},... on JiraSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template,description,project,summary},... on SymphonySettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template}}}}}:{\"input\":{\"reportGroups\":[{\"bindings\":[\"8016ae95-efa5-4de0-a96a-603cecfc57f4\"],\"emailSettings\":null,\"enabled\":true,\"groupBy\":[\"account\",\"region\"],\"name\":\"test-report-group\",\"schedule\":\"0 12 * * *\",\"source\":\"BINDING\",\"useMessageSettings\":true}]}}": [
+  "mutation ($input:UpsertReportGroupsInput!){upsertReportGroups(input: $input){reportGroups{id,name,enabled,bindings,source,schedule,groupBy,useMessageSettings,deliverySettings{__typename,... on EmailSettings{cc,firstMatchOnly,format,fromEmail,priority,recipients{account_owner,event_owner,resource_owner,tag,value},subject,template},... on SlackSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on TeamsSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on ServiceNowSettings{firstMatchOnly,impact,recipients{account_owner,event_owner,resource_owner,tag,value},shortDescription,template,urgency},... on JiraSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template,description,project,summary},... on SymphonySettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template}}}}}:{\"input\":{\"reportGroups\":[{\"bindings\":[\"a7e6a5c5-6ec1-4ccc-a5e0-c5e43df74cbd\"],\"emailSettings\":null,\"enabled\":true,\"groupBy\":[\"account\",\"region\"],\"jiraSettings\":null,\"name\":\"test-report-group\",\"schedule\":\"0 12 * * *\",\"serviceNowSettings\":null,\"slackSettings\":null,\"source\":\"BINDING\",\"symphonySettings\":null,\"teamsSettings\":null,\"useMessageSettings\":true}]}}": [
     {
       "request": {
         "query": "mutation ($input:UpsertReportGroupsInput!){upsertReportGroups(input: $input){reportGroups{id,name,enabled,bindings,source,schedule,groupBy,useMessageSettings,deliverySettings{__typename,... on EmailSettings{cc,firstMatchOnly,format,fromEmail,priority,recipients{account_owner,event_owner,resource_owner,tag,value},subject,template},... on SlackSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on TeamsSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on ServiceNowSettings{firstMatchOnly,impact,recipients{account_owner,event_owner,resource_owner,tag,value},shortDescription,template,urgency},... on JiraSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template,description,project,summary},... on SymphonySettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template}}}}}",
@@ -127,7 +127,7 @@
             "reportGroups": [
               {
                 "bindings": [
-                  "8016ae95-efa5-4de0-a96a-603cecfc57f4"
+                  "a7e6a5c5-6ec1-4ccc-a5e0-c5e43df74cbd"
                 ],
                 "emailSettings": null,
                 "enabled": true,
@@ -135,9 +135,14 @@
                   "account",
                   "region"
                 ],
+                "jiraSettings": null,
                 "name": "test-report-group",
                 "schedule": "0 12 * * *",
+                "serviceNowSettings": null,
+                "slackSettings": null,
                 "source": "BINDING",
+                "symphonySettings": null,
+                "teamsSettings": null,
                 "useMessageSettings": true
               }
             ]
@@ -150,7 +155,7 @@
             "reportGroups": [
               {
                 "bindings": [
-                  "8016ae95-efa5-4de0-a96a-603cecfc57f4"
+                  "a7e6a5c5-6ec1-4ccc-a5e0-c5e43df74cbd"
                 ],
                 "deliverySettings": [],
                 "enabled": true,
@@ -170,7 +175,7 @@
       }
     }
   ],
-  "mutation ($input:UpsertReportGroupsInput!){upsertReportGroups(input: $input){reportGroups{id,name,enabled,bindings,source,schedule,groupBy,useMessageSettings,deliverySettings{__typename,... on EmailSettings{cc,firstMatchOnly,format,fromEmail,priority,recipients{account_owner,event_owner,resource_owner,tag,value},subject,template},... on SlackSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on TeamsSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on ServiceNowSettings{firstMatchOnly,impact,recipients{account_owner,event_owner,resource_owner,tag,value},shortDescription,template,urgency},... on JiraSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template,description,project,summary},... on SymphonySettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template}}}}}:{\"input\":{\"reportGroups\":[{\"bindings\":[],\"emailSettings\":null,\"enabled\":false,\"groupBy\":[\"account\"],\"name\":\"test-report-group\",\"schedule\":\"0 6 * * *\",\"source\":\"BINDING\",\"useMessageSettings\":true}]}}": [
+  "mutation ($input:UpsertReportGroupsInput!){upsertReportGroups(input: $input){reportGroups{id,name,enabled,bindings,source,schedule,groupBy,useMessageSettings,deliverySettings{__typename,... on EmailSettings{cc,firstMatchOnly,format,fromEmail,priority,recipients{account_owner,event_owner,resource_owner,tag,value},subject,template},... on SlackSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on TeamsSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on ServiceNowSettings{firstMatchOnly,impact,recipients{account_owner,event_owner,resource_owner,tag,value},shortDescription,template,urgency},... on JiraSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template,description,project,summary},... on SymphonySettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template}}}}}:{\"input\":{\"reportGroups\":[{\"bindings\":[],\"emailSettings\":null,\"enabled\":false,\"groupBy\":[\"account\"],\"jiraSettings\":null,\"name\":\"test-report-group\",\"schedule\":\"0 6 * * *\",\"serviceNowSettings\":null,\"slackSettings\":null,\"source\":\"BINDING\",\"symphonySettings\":null,\"teamsSettings\":null,\"useMessageSettings\":true}]}}": [
     {
       "request": {
         "query": "mutation ($input:UpsertReportGroupsInput!){upsertReportGroups(input: $input){reportGroups{id,name,enabled,bindings,source,schedule,groupBy,useMessageSettings,deliverySettings{__typename,... on EmailSettings{cc,firstMatchOnly,format,fromEmail,priority,recipients{account_owner,event_owner,resource_owner,tag,value},subject,template},... on SlackSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on TeamsSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on ServiceNowSettings{firstMatchOnly,impact,recipients{account_owner,event_owner,resource_owner,tag,value},shortDescription,template,urgency},... on JiraSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template,description,project,summary},... on SymphonySettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template}}}}}",
@@ -184,9 +189,14 @@
                 "groupBy": [
                   "account"
                 ],
+                "jiraSettings": null,
                 "name": "test-report-group",
                 "schedule": "0 6 * * *",
+                "serviceNowSettings": null,
+                "slackSettings": null,
                 "source": "BINDING",
+                "symphonySettings": null,
+                "teamsSettings": null,
                 "useMessageSettings": true
               }
             ]
@@ -216,7 +226,7 @@
       }
     }
   ],
-  "mutation ($input:UpsertReportGroupsInput!){upsertReportGroups(input: $input){reportGroups{id,name,enabled,bindings,source,schedule,groupBy,useMessageSettings,deliverySettings{__typename,... on EmailSettings{cc,firstMatchOnly,format,fromEmail,priority,recipients{account_owner,event_owner,resource_owner,tag,value},subject,template},... on SlackSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on TeamsSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on ServiceNowSettings{firstMatchOnly,impact,recipients{account_owner,event_owner,resource_owner,tag,value},shortDescription,template,urgency},... on JiraSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template,description,project,summary},... on SymphonySettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template}}}}}:{\"input\":{\"reportGroups\":[{\"bindings\":[],\"emailSettings\":null,\"enabled\":true,\"groupBy\":[\"account\"],\"name\":\"test-report-group-renamed\",\"schedule\":\"0 12 * * *\",\"source\":\"BINDING\",\"useMessageSettings\":true}]}}": [
+  "mutation ($input:UpsertReportGroupsInput!){upsertReportGroups(input: $input){reportGroups{id,name,enabled,bindings,source,schedule,groupBy,useMessageSettings,deliverySettings{__typename,... on EmailSettings{cc,firstMatchOnly,format,fromEmail,priority,recipients{account_owner,event_owner,resource_owner,tag,value},subject,template},... on SlackSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on TeamsSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on ServiceNowSettings{firstMatchOnly,impact,recipients{account_owner,event_owner,resource_owner,tag,value},shortDescription,template,urgency},... on JiraSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template,description,project,summary},... on SymphonySettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template}}}}}:{\"input\":{\"reportGroups\":[{\"bindings\":[],\"emailSettings\":null,\"enabled\":true,\"groupBy\":[\"account\"],\"jiraSettings\":null,\"name\":\"test-report-group-renamed\",\"schedule\":\"0 12 * * *\",\"serviceNowSettings\":null,\"slackSettings\":null,\"source\":\"BINDING\",\"symphonySettings\":null,\"teamsSettings\":null,\"useMessageSettings\":true}]}}": [
     {
       "request": {
         "query": "mutation ($input:UpsertReportGroupsInput!){upsertReportGroups(input: $input){reportGroups{id,name,enabled,bindings,source,schedule,groupBy,useMessageSettings,deliverySettings{__typename,... on EmailSettings{cc,firstMatchOnly,format,fromEmail,priority,recipients{account_owner,event_owner,resource_owner,tag,value},subject,template},... on SlackSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on TeamsSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on ServiceNowSettings{firstMatchOnly,impact,recipients{account_owner,event_owner,resource_owner,tag,value},shortDescription,template,urgency},... on JiraSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template,description,project,summary},... on SymphonySettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template}}}}}",
@@ -230,9 +240,14 @@
                 "groupBy": [
                   "account"
                 ],
+                "jiraSettings": null,
                 "name": "test-report-group-renamed",
                 "schedule": "0 12 * * *",
+                "serviceNowSettings": null,
+                "slackSettings": null,
                 "source": "BINDING",
+                "symphonySettings": null,
+                "teamsSettings": null,
                 "useMessageSettings": true
               }
             ]
@@ -300,83 +315,83 @@
       }
     }
   ],
-  "mutation ($uuid:String!){removeAccountGroup(uuid: $uuid){group{uuid}}}:{\"uuid\":\"dfe48972-abef-4e28-87b0-4bfa47cbcc23\"}": [
+  "mutation ($uuid:String!){removeAccountGroup(uuid: $uuid){group{uuid}}}:{\"uuid\":\"5d782d87-9411-4fe6-8b88-3140a0be0438\"}": [
     {
       "request": {
         "query": "mutation ($uuid:String!){removeAccountGroup(uuid: $uuid){group{uuid}}}",
         "variables": {
-          "uuid": "dfe48972-abef-4e28-87b0-4bfa47cbcc23"
+          "uuid": "5d782d87-9411-4fe6-8b88-3140a0be0438"
         }
       },
       "response": {
         "data": {
           "removeAccountGroup": {
             "group": {
-              "uuid": "dfe48972-abef-4e28-87b0-4bfa47cbcc23"
+              "uuid": "5d782d87-9411-4fe6-8b88-3140a0be0438"
             }
           }
         }
       }
     }
   ],
-  "mutation ($uuid:String!){removeBinding(uuid: $uuid){binding{uuid}}}:{\"uuid\":\"8016ae95-efa5-4de0-a96a-603cecfc57f4\"}": [
+  "mutation ($uuid:String!){removeBinding(uuid: $uuid){binding{uuid}}}:{\"uuid\":\"a7e6a5c5-6ec1-4ccc-a5e0-c5e43df74cbd\"}": [
     {
       "request": {
         "query": "mutation ($uuid:String!){removeBinding(uuid: $uuid){binding{uuid}}}",
         "variables": {
-          "uuid": "8016ae95-efa5-4de0-a96a-603cecfc57f4"
+          "uuid": "a7e6a5c5-6ec1-4ccc-a5e0-c5e43df74cbd"
         }
       },
       "response": {
         "data": {
           "removeBinding": {
             "binding": {
-              "uuid": "8016ae95-efa5-4de0-a96a-603cecfc57f4"
+              "uuid": "a7e6a5c5-6ec1-4ccc-a5e0-c5e43df74cbd"
             }
           }
         }
       }
     }
   ],
-  "mutation ($uuid:String!){removePolicyCollection(uuid: $uuid){collection{uuid}}}:{\"uuid\":\"23d515cb-9b8d-45f4-8d9b-69756ba8eef2\"}": [
+  "mutation ($uuid:String!){removePolicyCollection(uuid: $uuid){collection{uuid}}}:{\"uuid\":\"a500e082-911e-41cd-834e-a53dee1fdffa\"}": [
     {
       "request": {
         "query": "mutation ($uuid:String!){removePolicyCollection(uuid: $uuid){collection{uuid}}}",
         "variables": {
-          "uuid": "23d515cb-9b8d-45f4-8d9b-69756ba8eef2"
+          "uuid": "a500e082-911e-41cd-834e-a53dee1fdffa"
         }
       },
       "response": {
         "data": {
           "removePolicyCollection": {
             "collection": {
-              "uuid": "23d515cb-9b8d-45f4-8d9b-69756ba8eef2"
+              "uuid": "a500e082-911e-41cd-834e-a53dee1fdffa"
             }
           }
         }
       }
     }
   ],
-  "query ($name:String!$uuid:String!){accountGroup(uuid: $uuid, name: $name){id,uuid,name,description,provider,regions}}:{\"name\":\"\",\"uuid\":\"dfe48972-abef-4e28-87b0-4bfa47cbcc23\"}": [
+  "query ($name:String!$uuid:String!){accountGroup(uuid: $uuid, name: $name){id,uuid,name,description,provider,regions}}:{\"name\":\"\",\"uuid\":\"5d782d87-9411-4fe6-8b88-3140a0be0438\"}": [
     {
       "request": {
         "query": "query ($name:String!$uuid:String!){accountGroup(uuid: $uuid, name: $name){id,uuid,name,description,provider,regions}}",
         "variables": {
           "name": "",
-          "uuid": "dfe48972-abef-4e28-87b0-4bfa47cbcc23"
+          "uuid": "5d782d87-9411-4fe6-8b88-3140a0be0438"
         }
       },
       "response": {
         "data": {
           "accountGroup": {
             "description": "Test account group for report group",
-            "id": "WyJhY2NvdW50LWdyb3VwIiwgImRmZTQ4OTcyLWFiZWYtNGUyOC04N2IwLTRiZmE0N2NiY2MyMyJd",
+            "id": "WyJhY2NvdW50LWdyb3VwIiwgIjVkNzgyZDg3LTk0MTEtNGZlNi04Yjg4LTMxNDBhMGJlMDQzOCJd",
             "name": "test-rg-ag",
             "provider": "AWS",
             "regions": [
               "us-east-1"
             ],
-            "uuid": "dfe48972-abef-4e28-87b0-4bfa47cbcc23"
+            "uuid": "5d782d87-9411-4fe6-8b88-3140a0be0438"
           }
         }
       }
@@ -386,39 +401,39 @@
         "query": "query ($name:String!$uuid:String!){accountGroup(uuid: $uuid, name: $name){id,uuid,name,description,provider,regions}}",
         "variables": {
           "name": "",
-          "uuid": "dfe48972-abef-4e28-87b0-4bfa47cbcc23"
+          "uuid": "5d782d87-9411-4fe6-8b88-3140a0be0438"
         }
       },
       "response": {
         "data": {
           "accountGroup": {
             "description": "Test account group for report group",
-            "id": "WyJhY2NvdW50LWdyb3VwIiwgImRmZTQ4OTcyLWFiZWYtNGUyOC04N2IwLTRiZmE0N2NiY2MyMyJd",
+            "id": "WyJhY2NvdW50LWdyb3VwIiwgIjVkNzgyZDg3LTk0MTEtNGZlNi04Yjg4LTMxNDBhMGJlMDQzOCJd",
             "name": "test-rg-ag",
             "provider": "AWS",
             "regions": [
               "us-east-1"
             ],
-            "uuid": "dfe48972-abef-4e28-87b0-4bfa47cbcc23"
+            "uuid": "5d782d87-9411-4fe6-8b88-3140a0be0438"
           }
         }
       }
     }
   ],
-  "query ($name:String!$uuid:String!){binding(uuid: $uuid, name: $name){id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}:{\"name\":\"\",\"uuid\":\"8016ae95-efa5-4de0-a96a-603cecfc57f4\"}": [
+  "query ($name:String!$uuid:String!){binding(uuid: $uuid, name: $name){id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}:{\"name\":\"\",\"uuid\":\"a7e6a5c5-6ec1-4ccc-a5e0-c5e43df74cbd\"}": [
     {
       "request": {
         "query": "query ($name:String!$uuid:String!){binding(uuid: $uuid, name: $name){id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}",
         "variables": {
           "name": "",
-          "uuid": "8016ae95-efa5-4de0-a96a-603cecfc57f4"
+          "uuid": "a7e6a5c5-6ec1-4ccc-a5e0-c5e43df74cbd"
         }
       },
       "response": {
         "data": {
           "binding": {
             "accountGroup": {
-              "uuid": "dfe48972-abef-4e28-87b0-4bfa47cbcc23"
+              "uuid": "5d782d87-9411-4fe6-8b88-3140a0be0438"
             },
             "autoDeploy": true,
             "description": "Test binding for report group",
@@ -428,14 +443,14 @@
               "securityContext": null,
               "variables": null
             },
-            "id": "WyJiaW5kaW5nIiwgIjgwMTZhZTk1LWVmYTUtNGRlMC1hOTZhLTYwM2NlY2ZjNTdmNCJd",
+            "id": "WyJiaW5kaW5nIiwgImE3ZTZhNWM1LTZlYzEtNGNjYy1hNWUwLWM1ZTQzZGY3NGNiZCJd",
             "name": "test-rg-binding",
             "policyCollection": {
-              "uuid": "23d515cb-9b8d-45f4-8d9b-69756ba8eef2"
+              "uuid": "a500e082-911e-41cd-834e-a53dee1fdffa"
             },
             "schedule": null,
             "system": false,
-            "uuid": "8016ae95-efa5-4de0-a96a-603cecfc57f4"
+            "uuid": "a7e6a5c5-6ec1-4ccc-a5e0-c5e43df74cbd"
           }
         }
       }
@@ -445,14 +460,14 @@
         "query": "query ($name:String!$uuid:String!){binding(uuid: $uuid, name: $name){id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}",
         "variables": {
           "name": "",
-          "uuid": "8016ae95-efa5-4de0-a96a-603cecfc57f4"
+          "uuid": "a7e6a5c5-6ec1-4ccc-a5e0-c5e43df74cbd"
         }
       },
       "response": {
         "data": {
           "binding": {
             "accountGroup": {
-              "uuid": "dfe48972-abef-4e28-87b0-4bfa47cbcc23"
+              "uuid": "5d782d87-9411-4fe6-8b88-3140a0be0438"
             },
             "autoDeploy": true,
             "description": "Test binding for report group",
@@ -462,26 +477,26 @@
               "securityContext": null,
               "variables": null
             },
-            "id": "WyJiaW5kaW5nIiwgIjgwMTZhZTk1LWVmYTUtNGRlMC1hOTZhLTYwM2NlY2ZjNTdmNCJd",
+            "id": "WyJiaW5kaW5nIiwgImE3ZTZhNWM1LTZlYzEtNGNjYy1hNWUwLWM1ZTQzZGY3NGNiZCJd",
             "name": "test-rg-binding",
             "policyCollection": {
-              "uuid": "23d515cb-9b8d-45f4-8d9b-69756ba8eef2"
+              "uuid": "a500e082-911e-41cd-834e-a53dee1fdffa"
             },
             "schedule": null,
             "system": false,
-            "uuid": "8016ae95-efa5-4de0-a96a-603cecfc57f4"
+            "uuid": "a7e6a5c5-6ec1-4ccc-a5e0-c5e43df74cbd"
           }
         }
       }
     }
   ],
-  "query ($name:String!$uuid:String!){policyCollection(uuid: $uuid, name: $name){id,uuid,name,description,provider,autoUpdate,system,isDynamic,repositoryConfig{uuid},repositoryView{namespace,branchName,policyDirectories,policyFileSuffix}}}:{\"name\":\"\",\"uuid\":\"23d515cb-9b8d-45f4-8d9b-69756ba8eef2\"}": [
+  "query ($name:String!$uuid:String!){policyCollection(uuid: $uuid, name: $name){id,uuid,name,description,provider,autoUpdate,system,isDynamic,repositoryConfig{uuid},repositoryView{namespace,branchName,policyDirectories,policyFileSuffix}}}:{\"name\":\"\",\"uuid\":\"a500e082-911e-41cd-834e-a53dee1fdffa\"}": [
     {
       "request": {
         "query": "query ($name:String!$uuid:String!){policyCollection(uuid: $uuid, name: $name){id,uuid,name,description,provider,autoUpdate,system,isDynamic,repositoryConfig{uuid},repositoryView{namespace,branchName,policyDirectories,policyFileSuffix}}}",
         "variables": {
           "name": "",
-          "uuid": "23d515cb-9b8d-45f4-8d9b-69756ba8eef2"
+          "uuid": "a500e082-911e-41cd-834e-a53dee1fdffa"
         }
       },
       "response": {
@@ -489,14 +504,14 @@
           "policyCollection": {
             "autoUpdate": false,
             "description": "Test policy collection for report group",
-            "id": "WyJwb2xpY3ktY29sbGVjdGlvbiIsICIyM2Q1MTVjYi05YjhkLTQ1ZjQtOGQ5Yi02OTc1NmJhOGVlZjIiXQ==",
+            "id": "WyJwb2xpY3ktY29sbGVjdGlvbiIsICJhNTAwZTA4Mi05MTFlLTQxY2QtODM0ZS1hNTNkZWUxZmRmZmEiXQ==",
             "isDynamic": false,
             "name": "test-rg-pc",
             "provider": "AWS",
             "repositoryConfig": null,
             "repositoryView": null,
             "system": false,
-            "uuid": "23d515cb-9b8d-45f4-8d9b-69756ba8eef2"
+            "uuid": "a500e082-911e-41cd-834e-a53dee1fdffa"
           }
         }
       }
@@ -506,7 +521,7 @@
         "query": "query ($name:String!$uuid:String!){policyCollection(uuid: $uuid, name: $name){id,uuid,name,description,provider,autoUpdate,system,isDynamic,repositoryConfig{uuid},repositoryView{namespace,branchName,policyDirectories,policyFileSuffix}}}",
         "variables": {
           "name": "",
-          "uuid": "23d515cb-9b8d-45f4-8d9b-69756ba8eef2"
+          "uuid": "a500e082-911e-41cd-834e-a53dee1fdffa"
         }
       },
       "response": {
@@ -514,14 +529,14 @@
           "policyCollection": {
             "autoUpdate": false,
             "description": "Test policy collection for report group",
-            "id": "WyJwb2xpY3ktY29sbGVjdGlvbiIsICIyM2Q1MTVjYi05YjhkLTQ1ZjQtOGQ5Yi02OTc1NmJhOGVlZjIiXQ==",
+            "id": "WyJwb2xpY3ktY29sbGVjdGlvbiIsICJhNTAwZTA4Mi05MTFlLTQxY2QtODM0ZS1hNTNkZWUxZmRmZmEiXQ==",
             "isDynamic": false,
             "name": "test-rg-pc",
             "provider": "AWS",
             "repositoryConfig": null,
             "repositoryView": null,
             "system": false,
-            "uuid": "23d515cb-9b8d-45f4-8d9b-69756ba8eef2"
+            "uuid": "a500e082-911e-41cd-834e-a53dee1fdffa"
           }
         }
       }
@@ -539,7 +554,7 @@
         "data": {
           "reportGroup": {
             "bindings": [
-              "8016ae95-efa5-4de0-a96a-603cecfc57f4"
+              "a7e6a5c5-6ec1-4ccc-a5e0-c5e43df74cbd"
             ],
             "deliverySettings": [],
             "enabled": true,
@@ -567,7 +582,7 @@
         "data": {
           "reportGroup": {
             "bindings": [
-              "8016ae95-efa5-4de0-a96a-603cecfc57f4"
+              "a7e6a5c5-6ec1-4ccc-a5e0-c5e43df74cbd"
             ],
             "deliverySettings": [],
             "enabled": true,
@@ -595,7 +610,7 @@
         "data": {
           "reportGroup": {
             "bindings": [
-              "8016ae95-efa5-4de0-a96a-603cecfc57f4"
+              "a7e6a5c5-6ec1-4ccc-a5e0-c5e43df74cbd"
             ],
             "deliverySettings": [],
             "enabled": true,

--- a/internal/acceptance_tests/recordings/TestAccReportGroupResource_DeliverySettings.json
+++ b/internal/acceptance_tests/recordings/TestAccReportGroupResource_DeliverySettings.json
@@ -19,26 +19,26 @@
           "addAccountGroup": {
             "group": {
               "description": "Test account group for report group",
-              "id": "WyJhY2NvdW50LWdyb3VwIiwgImQxMzAzMmQ4LTNjYzEtNDY3OS04MDhjLTg3NTUwMzkzYWU2YiJd",
+              "id": "WyJhY2NvdW50LWdyb3VwIiwgIjllNDgwODc3LWJjMDQtNGRkYy1hM2NiLWE4MzdhYWM0YjllYSJd",
               "name": "test-rg-ag",
               "provider": "AWS",
               "regions": [
                 "us-east-1"
               ],
-              "uuid": "d13032d8-3cc1-4679-808c-87550393ae6b"
+              "uuid": "9e480877-bc04-4ddc-a3cb-a837aac4b9ea"
             }
           }
         }
       }
     }
   ],
-  "mutation ($input:AddBindingInput!){addBinding(input: $input){binding{id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}}:{\"input\":{\"accountGroupUUID\":\"d13032d8-3cc1-4679-808c-87550393ae6b\",\"autoDeploy\":true,\"deploy\":true,\"description\":\"Test binding for report group\",\"executionConfig\":{\"dryRun\":null,\"resourceLimits\":{\"default\":null,\"policyOverrides\":[]},\"securityContext\":null,\"variables\":null},\"name\":\"test-rg-binding\",\"policyCollectionUUID\":\"a098c33d-a41a-4d85-b073-a9f36595a3b9\"}}": [
+  "mutation ($input:AddBindingInput!){addBinding(input: $input){binding{id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}}:{\"input\":{\"accountGroupUUID\":\"9e480877-bc04-4ddc-a3cb-a837aac4b9ea\",\"autoDeploy\":true,\"deploy\":true,\"description\":\"Test binding for report group\",\"executionConfig\":{\"dryRun\":null,\"resourceLimits\":{\"default\":null,\"policyOverrides\":[]},\"securityContext\":null,\"variables\":null},\"name\":\"test-rg-binding\",\"policyCollectionUUID\":\"41ce180c-7b71-4b41-ae81-0e747e944d8f\"}}": [
     {
       "request": {
         "query": "mutation ($input:AddBindingInput!){addBinding(input: $input){binding{id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}}",
         "variables": {
           "input": {
-            "accountGroupUUID": "d13032d8-3cc1-4679-808c-87550393ae6b",
+            "accountGroupUUID": "9e480877-bc04-4ddc-a3cb-a837aac4b9ea",
             "autoDeploy": true,
             "deploy": true,
             "description": "Test binding for report group",
@@ -52,7 +52,7 @@
               "variables": null
             },
             "name": "test-rg-binding",
-            "policyCollectionUUID": "a098c33d-a41a-4d85-b073-a9f36595a3b9"
+            "policyCollectionUUID": "41ce180c-7b71-4b41-ae81-0e747e944d8f"
           }
         }
       },
@@ -61,7 +61,7 @@
           "addBinding": {
             "binding": {
               "accountGroup": {
-                "uuid": "d13032d8-3cc1-4679-808c-87550393ae6b"
+                "uuid": "9e480877-bc04-4ddc-a3cb-a837aac4b9ea"
               },
               "autoDeploy": true,
               "description": "Test binding for report group",
@@ -71,14 +71,14 @@
                 "securityContext": null,
                 "variables": null
               },
-              "id": "WyJiaW5kaW5nIiwgIjk5NjFiNjc1LTAxMGYtNDVjYy1iNmU4LTM2NGZjY2UyZjhmYiJd",
+              "id": "WyJiaW5kaW5nIiwgIjcxNjNiYzhjLTgyNjktNGY1Zi1hODA1LTAzZGRjYTVhYmNjMCJd",
               "name": "test-rg-binding",
               "policyCollection": {
-                "uuid": "a098c33d-a41a-4d85-b073-a9f36595a3b9"
+                "uuid": "41ce180c-7b71-4b41-ae81-0e747e944d8f"
               },
               "schedule": null,
               "system": false,
-              "uuid": "9961b675-010f-45cc-b6e8-364fcce2f8fb"
+              "uuid": "7163bc8c-8269-4f5f-a805-03ddca5abcc0"
             }
           }
         }
@@ -104,21 +104,21 @@
             "collection": {
               "autoUpdate": false,
               "description": "Test policy collection for report group",
-              "id": "WyJwb2xpY3ktY29sbGVjdGlvbiIsICJhMDk4YzMzZC1hNDFhLTRkODUtYjA3My1hOWYzNjU5NWEzYjkiXQ==",
+              "id": "WyJwb2xpY3ktY29sbGVjdGlvbiIsICI0MWNlMTgwYy03YjcxLTRiNDEtYWU4MS0wZTc0N2U5NDRkOGYiXQ==",
               "isDynamic": false,
               "name": "test-rg-pc",
               "provider": "AWS",
               "repositoryConfig": null,
               "repositoryView": null,
               "system": false,
-              "uuid": "a098c33d-a41a-4d85-b073-a9f36595a3b9"
+              "uuid": "41ce180c-7b71-4b41-ae81-0e747e944d8f"
             }
           }
         }
       }
     }
   ],
-  "mutation ($input:UpsertReportGroupsInput!){upsertReportGroups(input: $input){reportGroups{id,name,enabled,bindings,source,schedule,groupBy,useMessageSettings,deliverySettings{__typename,... on EmailSettings{cc,firstMatchOnly,format,fromEmail,priority,recipients{account_owner,event_owner,resource_owner,tag,value},subject,template},... on SlackSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on TeamsSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on ServiceNowSettings{firstMatchOnly,impact,recipients{account_owner,event_owner,resource_owner,tag,value},shortDescription,template,urgency},... on JiraSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template,description,project,summary},... on SymphonySettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template}}}}}:{\"input\":{\"reportGroups\":[{\"bindings\":[\"9961b675-010f-45cc-b6e8-364fcce2f8fb\"],\"emailSettings\":[{\"cc\":[],\"firstMatchOnly\":false,\"format\":\"\",\"fromEmail\":null,\"priority\":\"3\",\"recipients\":[{\"account_owner\":null,\"event_owner\":null,\"resource_owner\":true,\"tag\":null,\"value\":null},{\"account_owner\":null,\"event_owner\":null,\"resource_owner\":null,\"tag\":null,\"value\":\"user@example.com\"}],\"subject\":\"Matched resources\",\"template\":\"template.html\"}],\"enabled\":true,\"groupBy\":[],\"name\":\"test-report-group\",\"schedule\":\"0 12 * * *\",\"source\":\"BINDING\",\"useMessageSettings\":true}]}}": [
+  "mutation ($input:UpsertReportGroupsInput!){upsertReportGroups(input: $input){reportGroups{id,name,enabled,bindings,source,schedule,groupBy,useMessageSettings,deliverySettings{__typename,... on EmailSettings{cc,firstMatchOnly,format,fromEmail,priority,recipients{account_owner,event_owner,resource_owner,tag,value},subject,template},... on SlackSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on TeamsSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on ServiceNowSettings{firstMatchOnly,impact,recipients{account_owner,event_owner,resource_owner,tag,value},shortDescription,template,urgency},... on JiraSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template,description,project,summary},... on SymphonySettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template}}}}}:{\"input\":{\"reportGroups\":[{\"bindings\":[\"7163bc8c-8269-4f5f-a805-03ddca5abcc0\"],\"emailSettings\":[{\"cc\":[],\"firstMatchOnly\":false,\"format\":\"\",\"fromEmail\":null,\"priority\":\"3\",\"recipients\":[{\"account_owner\":null,\"event_owner\":null,\"resource_owner\":true,\"tag\":null,\"value\":null},{\"account_owner\":null,\"event_owner\":null,\"resource_owner\":null,\"tag\":null,\"value\":\"user@example.com\"}],\"subject\":\"Matched resources\",\"template\":\"email\"}],\"enabled\":true,\"groupBy\":[],\"jiraSettings\":[{\"description\":\"matched resources\",\"firstMatchOnly\":false,\"project\":\"prj\",\"recipients\":[],\"summary\":\"short summary\",\"template\":\"jira\"}],\"name\":\"test-report-group\",\"schedule\":\"0 12 * * *\",\"serviceNowSettings\":[{\"firstMatchOnly\":false,\"impact\":\"2\",\"recipients\":[],\"shortDescription\":\"matched resources\",\"template\":\"servicenow\",\"urgency\":\"1\"}],\"slackSettings\":[{\"firstMatchOnly\":false,\"recipients\":[{\"account_owner\":true,\"event_owner\":null,\"resource_owner\":null,\"tag\":null,\"value\":null}],\"template\":\"slack\"}],\"source\":\"BINDING\",\"symphonySettings\":[{\"firstMatchOnly\":false,\"recipients\":[{\"account_owner\":null,\"event_owner\":null,\"resource_owner\":true,\"tag\":null,\"value\":null},{\"account_owner\":true,\"event_owner\":null,\"resource_owner\":null,\"tag\":null,\"value\":null}],\"template\":\"symphony\"}],\"teamsSettings\":[{\"firstMatchOnly\":false,\"recipients\":[{\"account_owner\":null,\"event_owner\":null,\"resource_owner\":null,\"tag\":\"foo\",\"value\":null}],\"template\":\"teams\"}],\"useMessageSettings\":true}]}}": [
     {
       "request": {
         "query": "mutation ($input:UpsertReportGroupsInput!){upsertReportGroups(input: $input){reportGroups{id,name,enabled,bindings,source,schedule,groupBy,useMessageSettings,deliverySettings{__typename,... on EmailSettings{cc,firstMatchOnly,format,fromEmail,priority,recipients{account_owner,event_owner,resource_owner,tag,value},subject,template},... on SlackSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on TeamsSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template},... on ServiceNowSettings{firstMatchOnly,impact,recipients{account_owner,event_owner,resource_owner,tag,value},shortDescription,template,urgency},... on JiraSettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template,description,project,summary},... on SymphonySettings{firstMatchOnly,recipients{account_owner,event_owner,resource_owner,tag,value},template}}}}}",
@@ -127,7 +127,7 @@
             "reportGroups": [
               {
                 "bindings": [
-                  "9961b675-010f-45cc-b6e8-364fcce2f8fb"
+                  "7163bc8c-8269-4f5f-a805-03ddca5abcc0"
                 ],
                 "emailSettings": [
                   {
@@ -153,14 +153,86 @@
                       }
                     ],
                     "subject": "Matched resources",
-                    "template": "template.html"
+                    "template": "email"
                   }
                 ],
                 "enabled": true,
                 "groupBy": [],
+                "jiraSettings": [
+                  {
+                    "description": "matched resources",
+                    "firstMatchOnly": false,
+                    "project": "prj",
+                    "recipients": [],
+                    "summary": "short summary",
+                    "template": "jira"
+                  }
+                ],
                 "name": "test-report-group",
                 "schedule": "0 12 * * *",
+                "serviceNowSettings": [
+                  {
+                    "firstMatchOnly": false,
+                    "impact": "2",
+                    "recipients": [],
+                    "shortDescription": "matched resources",
+                    "template": "servicenow",
+                    "urgency": "1"
+                  }
+                ],
+                "slackSettings": [
+                  {
+                    "firstMatchOnly": false,
+                    "recipients": [
+                      {
+                        "account_owner": true,
+                        "event_owner": null,
+                        "resource_owner": null,
+                        "tag": null,
+                        "value": null
+                      }
+                    ],
+                    "template": "slack"
+                  }
+                ],
                 "source": "BINDING",
+                "symphonySettings": [
+                  {
+                    "firstMatchOnly": false,
+                    "recipients": [
+                      {
+                        "account_owner": null,
+                        "event_owner": null,
+                        "resource_owner": true,
+                        "tag": null,
+                        "value": null
+                      },
+                      {
+                        "account_owner": true,
+                        "event_owner": null,
+                        "resource_owner": null,
+                        "tag": null,
+                        "value": null
+                      }
+                    ],
+                    "template": "symphony"
+                  }
+                ],
+                "teamsSettings": [
+                  {
+                    "firstMatchOnly": false,
+                    "recipients": [
+                      {
+                        "account_owner": null,
+                        "event_owner": null,
+                        "resource_owner": null,
+                        "tag": "foo",
+                        "value": null
+                      }
+                    ],
+                    "template": "teams"
+                  }
+                ],
                 "useMessageSettings": true
               }
             ]
@@ -173,7 +245,7 @@
             "reportGroups": [
               {
                 "bindings": [
-                  "9961b675-010f-45cc-b6e8-364fcce2f8fb"
+                  "7163bc8c-8269-4f5f-a805-03ddca5abcc0"
                 ],
                 "deliverySettings": [
                   {
@@ -200,7 +272,74 @@
                       }
                     ],
                     "subject": "Matched resources",
-                    "template": "template.html"
+                    "template": "email"
+                  },
+                  {
+                    "__typename": "SlackSettings",
+                    "firstMatchOnly": false,
+                    "recipients": [
+                      {
+                        "account_owner": true,
+                        "event_owner": null,
+                        "resource_owner": null,
+                        "tag": null,
+                        "value": null
+                      }
+                    ],
+                    "template": "slack"
+                  },
+                  {
+                    "__typename": "TeamsSettings",
+                    "firstMatchOnly": false,
+                    "recipients": [
+                      {
+                        "account_owner": null,
+                        "event_owner": null,
+                        "resource_owner": null,
+                        "tag": "foo",
+                        "value": null
+                      }
+                    ],
+                    "template": "teams"
+                  },
+                  {
+                    "__typename": "JiraSettings",
+                    "description": "matched resources",
+                    "firstMatchOnly": false,
+                    "project": "prj",
+                    "recipients": [],
+                    "summary": "short summary",
+                    "template": "jira"
+                  },
+                  {
+                    "__typename": "ServiceNowSettings",
+                    "firstMatchOnly": false,
+                    "impact": "2",
+                    "recipients": [],
+                    "shortDescription": "matched resources",
+                    "template": "servicenow",
+                    "urgency": "1"
+                  },
+                  {
+                    "__typename": "SymphonySettings",
+                    "firstMatchOnly": false,
+                    "recipients": [
+                      {
+                        "account_owner": null,
+                        "event_owner": null,
+                        "resource_owner": true,
+                        "tag": null,
+                        "value": null
+                      },
+                      {
+                        "account_owner": true,
+                        "event_owner": null,
+                        "resource_owner": null,
+                        "tag": null,
+                        "value": null
+                      }
+                    ],
+                    "template": "symphony"
                   }
                 ],
                 "enabled": true,
@@ -236,102 +375,102 @@
       }
     }
   ],
-  "mutation ($uuid:String!){removeAccountGroup(uuid: $uuid){group{uuid}}}:{\"uuid\":\"d13032d8-3cc1-4679-808c-87550393ae6b\"}": [
+  "mutation ($uuid:String!){removeAccountGroup(uuid: $uuid){group{uuid}}}:{\"uuid\":\"9e480877-bc04-4ddc-a3cb-a837aac4b9ea\"}": [
     {
       "request": {
         "query": "mutation ($uuid:String!){removeAccountGroup(uuid: $uuid){group{uuid}}}",
         "variables": {
-          "uuid": "d13032d8-3cc1-4679-808c-87550393ae6b"
+          "uuid": "9e480877-bc04-4ddc-a3cb-a837aac4b9ea"
         }
       },
       "response": {
         "data": {
           "removeAccountGroup": {
             "group": {
-              "uuid": "d13032d8-3cc1-4679-808c-87550393ae6b"
+              "uuid": "9e480877-bc04-4ddc-a3cb-a837aac4b9ea"
             }
           }
         }
       }
     }
   ],
-  "mutation ($uuid:String!){removeBinding(uuid: $uuid){binding{uuid}}}:{\"uuid\":\"9961b675-010f-45cc-b6e8-364fcce2f8fb\"}": [
+  "mutation ($uuid:String!){removeBinding(uuid: $uuid){binding{uuid}}}:{\"uuid\":\"7163bc8c-8269-4f5f-a805-03ddca5abcc0\"}": [
     {
       "request": {
         "query": "mutation ($uuid:String!){removeBinding(uuid: $uuid){binding{uuid}}}",
         "variables": {
-          "uuid": "9961b675-010f-45cc-b6e8-364fcce2f8fb"
+          "uuid": "7163bc8c-8269-4f5f-a805-03ddca5abcc0"
         }
       },
       "response": {
         "data": {
           "removeBinding": {
             "binding": {
-              "uuid": "9961b675-010f-45cc-b6e8-364fcce2f8fb"
+              "uuid": "7163bc8c-8269-4f5f-a805-03ddca5abcc0"
             }
           }
         }
       }
     }
   ],
-  "mutation ($uuid:String!){removePolicyCollection(uuid: $uuid){collection{uuid}}}:{\"uuid\":\"a098c33d-a41a-4d85-b073-a9f36595a3b9\"}": [
+  "mutation ($uuid:String!){removePolicyCollection(uuid: $uuid){collection{uuid}}}:{\"uuid\":\"41ce180c-7b71-4b41-ae81-0e747e944d8f\"}": [
     {
       "request": {
         "query": "mutation ($uuid:String!){removePolicyCollection(uuid: $uuid){collection{uuid}}}",
         "variables": {
-          "uuid": "a098c33d-a41a-4d85-b073-a9f36595a3b9"
+          "uuid": "41ce180c-7b71-4b41-ae81-0e747e944d8f"
         }
       },
       "response": {
         "data": {
           "removePolicyCollection": {
             "collection": {
-              "uuid": "a098c33d-a41a-4d85-b073-a9f36595a3b9"
+              "uuid": "41ce180c-7b71-4b41-ae81-0e747e944d8f"
             }
           }
         }
       }
     }
   ],
-  "query ($name:String!$uuid:String!){accountGroup(uuid: $uuid, name: $name){id,uuid,name,description,provider,regions}}:{\"name\":\"\",\"uuid\":\"d13032d8-3cc1-4679-808c-87550393ae6b\"}": [
+  "query ($name:String!$uuid:String!){accountGroup(uuid: $uuid, name: $name){id,uuid,name,description,provider,regions}}:{\"name\":\"\",\"uuid\":\"9e480877-bc04-4ddc-a3cb-a837aac4b9ea\"}": [
     {
       "request": {
         "query": "query ($name:String!$uuid:String!){accountGroup(uuid: $uuid, name: $name){id,uuid,name,description,provider,regions}}",
         "variables": {
           "name": "",
-          "uuid": "d13032d8-3cc1-4679-808c-87550393ae6b"
+          "uuid": "9e480877-bc04-4ddc-a3cb-a837aac4b9ea"
         }
       },
       "response": {
         "data": {
           "accountGroup": {
             "description": "Test account group for report group",
-            "id": "WyJhY2NvdW50LWdyb3VwIiwgImQxMzAzMmQ4LTNjYzEtNDY3OS04MDhjLTg3NTUwMzkzYWU2YiJd",
+            "id": "WyJhY2NvdW50LWdyb3VwIiwgIjllNDgwODc3LWJjMDQtNGRkYy1hM2NiLWE4MzdhYWM0YjllYSJd",
             "name": "test-rg-ag",
             "provider": "AWS",
             "regions": [
               "us-east-1"
             ],
-            "uuid": "d13032d8-3cc1-4679-808c-87550393ae6b"
+            "uuid": "9e480877-bc04-4ddc-a3cb-a837aac4b9ea"
           }
         }
       }
     }
   ],
-  "query ($name:String!$uuid:String!){binding(uuid: $uuid, name: $name){id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}:{\"name\":\"\",\"uuid\":\"9961b675-010f-45cc-b6e8-364fcce2f8fb\"}": [
+  "query ($name:String!$uuid:String!){binding(uuid: $uuid, name: $name){id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}:{\"name\":\"\",\"uuid\":\"7163bc8c-8269-4f5f-a805-03ddca5abcc0\"}": [
     {
       "request": {
         "query": "query ($name:String!$uuid:String!){binding(uuid: $uuid, name: $name){id,uuid,name,description,autoDeploy,schedule,accountGroup{uuid},policyCollection{uuid},executionConfig{dryRun{default},resourceLimits{default{maxCount,maxPercentage,requiresBoth},policyOverrides{limit{maxCount,maxPercentage,requiresBoth},policyName}},securityContext{default},variables},system}}",
         "variables": {
           "name": "",
-          "uuid": "9961b675-010f-45cc-b6e8-364fcce2f8fb"
+          "uuid": "7163bc8c-8269-4f5f-a805-03ddca5abcc0"
         }
       },
       "response": {
         "data": {
           "binding": {
             "accountGroup": {
-              "uuid": "d13032d8-3cc1-4679-808c-87550393ae6b"
+              "uuid": "9e480877-bc04-4ddc-a3cb-a837aac4b9ea"
             },
             "autoDeploy": true,
             "description": "Test binding for report group",
@@ -341,26 +480,26 @@
               "securityContext": null,
               "variables": null
             },
-            "id": "WyJiaW5kaW5nIiwgIjk5NjFiNjc1LTAxMGYtNDVjYy1iNmU4LTM2NGZjY2UyZjhmYiJd",
+            "id": "WyJiaW5kaW5nIiwgIjcxNjNiYzhjLTgyNjktNGY1Zi1hODA1LTAzZGRjYTVhYmNjMCJd",
             "name": "test-rg-binding",
             "policyCollection": {
-              "uuid": "a098c33d-a41a-4d85-b073-a9f36595a3b9"
+              "uuid": "41ce180c-7b71-4b41-ae81-0e747e944d8f"
             },
             "schedule": null,
             "system": false,
-            "uuid": "9961b675-010f-45cc-b6e8-364fcce2f8fb"
+            "uuid": "7163bc8c-8269-4f5f-a805-03ddca5abcc0"
           }
         }
       }
     }
   ],
-  "query ($name:String!$uuid:String!){policyCollection(uuid: $uuid, name: $name){id,uuid,name,description,provider,autoUpdate,system,isDynamic,repositoryConfig{uuid},repositoryView{namespace,branchName,policyDirectories,policyFileSuffix}}}:{\"name\":\"\",\"uuid\":\"a098c33d-a41a-4d85-b073-a9f36595a3b9\"}": [
+  "query ($name:String!$uuid:String!){policyCollection(uuid: $uuid, name: $name){id,uuid,name,description,provider,autoUpdate,system,isDynamic,repositoryConfig{uuid},repositoryView{namespace,branchName,policyDirectories,policyFileSuffix}}}:{\"name\":\"\",\"uuid\":\"41ce180c-7b71-4b41-ae81-0e747e944d8f\"}": [
     {
       "request": {
         "query": "query ($name:String!$uuid:String!){policyCollection(uuid: $uuid, name: $name){id,uuid,name,description,provider,autoUpdate,system,isDynamic,repositoryConfig{uuid},repositoryView{namespace,branchName,policyDirectories,policyFileSuffix}}}",
         "variables": {
           "name": "",
-          "uuid": "a098c33d-a41a-4d85-b073-a9f36595a3b9"
+          "uuid": "41ce180c-7b71-4b41-ae81-0e747e944d8f"
         }
       },
       "response": {
@@ -368,14 +507,14 @@
           "policyCollection": {
             "autoUpdate": false,
             "description": "Test policy collection for report group",
-            "id": "WyJwb2xpY3ktY29sbGVjdGlvbiIsICJhMDk4YzMzZC1hNDFhLTRkODUtYjA3My1hOWYzNjU5NWEzYjkiXQ==",
+            "id": "WyJwb2xpY3ktY29sbGVjdGlvbiIsICI0MWNlMTgwYy03YjcxLTRiNDEtYWU4MS0wZTc0N2U5NDRkOGYiXQ==",
             "isDynamic": false,
             "name": "test-rg-pc",
             "provider": "AWS",
             "repositoryConfig": null,
             "repositoryView": null,
             "system": false,
-            "uuid": "a098c33d-a41a-4d85-b073-a9f36595a3b9"
+            "uuid": "41ce180c-7b71-4b41-ae81-0e747e944d8f"
           }
         }
       }
@@ -393,7 +532,7 @@
         "data": {
           "reportGroup": {
             "bindings": [
-              "9961b675-010f-45cc-b6e8-364fcce2f8fb"
+              "7163bc8c-8269-4f5f-a805-03ddca5abcc0"
             ],
             "deliverySettings": [
               {
@@ -420,7 +559,74 @@
                   }
                 ],
                 "subject": "Matched resources",
-                "template": "template.html"
+                "template": "email"
+              },
+              {
+                "__typename": "SlackSettings",
+                "firstMatchOnly": false,
+                "recipients": [
+                  {
+                    "account_owner": true,
+                    "event_owner": null,
+                    "resource_owner": null,
+                    "tag": null,
+                    "value": null
+                  }
+                ],
+                "template": "slack"
+              },
+              {
+                "__typename": "TeamsSettings",
+                "firstMatchOnly": false,
+                "recipients": [
+                  {
+                    "account_owner": null,
+                    "event_owner": null,
+                    "resource_owner": null,
+                    "tag": "foo",
+                    "value": null
+                  }
+                ],
+                "template": "teams"
+              },
+              {
+                "__typename": "JiraSettings",
+                "description": "matched resources",
+                "firstMatchOnly": false,
+                "project": "prj",
+                "recipients": [],
+                "summary": "short summary",
+                "template": "jira"
+              },
+              {
+                "__typename": "ServiceNowSettings",
+                "firstMatchOnly": false,
+                "impact": "2",
+                "recipients": [],
+                "shortDescription": "matched resources",
+                "template": "servicenow",
+                "urgency": "1"
+              },
+              {
+                "__typename": "SymphonySettings",
+                "firstMatchOnly": false,
+                "recipients": [
+                  {
+                    "account_owner": null,
+                    "event_owner": null,
+                    "resource_owner": true,
+                    "tag": null,
+                    "value": null
+                  },
+                  {
+                    "account_owner": true,
+                    "event_owner": null,
+                    "resource_owner": null,
+                    "tag": null,
+                    "value": null
+                  }
+                ],
+                "template": "symphony"
               }
             ],
             "enabled": true,

--- a/internal/acceptance_tests/report_group_data_source_test.go
+++ b/internal/acceptance_tests/report_group_data_source_test.go
@@ -38,6 +38,20 @@ func TestAccReportGroupDataSource(t *testing.T) {
 						bindings = [stacklet_binding.b.uuid]
 						schedule = "0 12 * * *"
 						group_by = ["account", "region"]
+
+	                    email_delivery_settings {
+                            template = "email"
+                            subject = "Matched resources"
+
+                            recipients = [
+                        	    {
+                                  resource_owner = true
+                                },
+                        	    {
+                                  value = "user@example.com"
+                                },
+                             ]
+                        }
 					}
 
                     data "stacklet_report_group" "test" {
@@ -57,6 +71,17 @@ func TestAccReportGroupDataSource(t *testing.T) {
 				resource.TestCheckResourceAttr("data.stacklet_report_group.test", "group_by.0", "account"),
 				resource.TestCheckResourceAttr("data.stacklet_report_group.test", "group_by.1", "region"),
 				resource.TestCheckResourceAttr("data.stacklet_report_group.test", "use_message_settings", "true"),
+				resource.TestCheckResourceAttr("data.stacklet_report_group.test", "email_delivery_settings.#", "1"),
+				resource.TestCheckResourceAttr("data.stacklet_report_group.test", "email_delivery_settings.0.template", "email"),
+				resource.TestCheckResourceAttr("data.stacklet_report_group.test", "email_delivery_settings.0.subject", "Matched resources"),
+				resource.TestCheckResourceAttr("data.stacklet_report_group.test", "email_delivery_settings.0.recipients.#", "2"),
+				resource.TestCheckResourceAttr("data.stacklet_report_group.test", "email_delivery_settings.0.recipients.0.resource_owner", "true"),
+				resource.TestCheckResourceAttr("data.stacklet_report_group.test", "email_delivery_settings.0.recipients.1.value", "user@example.com"),
+				resource.TestCheckResourceAttr("data.stacklet_report_group.test", "slack_delivery_settings.#", "0"),
+				resource.TestCheckResourceAttr("data.stacklet_report_group.test", "teams_delivery_settings.#", "0"),
+				resource.TestCheckResourceAttr("data.stacklet_report_group.test", "servicenow_delivery_settings.#", "0"),
+				resource.TestCheckResourceAttr("data.stacklet_report_group.test", "jira_delivery_settings.#", "0"),
+				resource.TestCheckResourceAttr("data.stacklet_report_group.test", "symphony_delivery_settings.#", "0"),
 			),
 		},
 	}

--- a/internal/acceptance_tests/report_group_resource_test.go
+++ b/internal/acceptance_tests/report_group_resource_test.go
@@ -140,7 +140,7 @@ func TestAccReportGroupResource_DeliverySettings(t *testing.T) {
 						schedule = "0 12 * * *"
 
 	                    email_delivery_settings {
-                            template = "template.html"
+                            template = "email"
                             subject = "Matched resources"
 
                             recipients = [
@@ -152,16 +152,87 @@ func TestAccReportGroupResource_DeliverySettings(t *testing.T) {
                                 },
                              ]
                         }
-	                    
+
+	                    slack_delivery_settings {
+                            template = "slack"
+                            
+                            recipients = [
+                        	    {
+                                  account_owner = true
+                                }
+	                        ]
+                        }
+
+	                    teams_delivery_settings {
+                            template = "teams"
+                            
+                            recipients = [
+                        	    {
+                                  tag = "foo"
+                                }
+	                        ]
+                        }
+
+	                    servicenow_delivery_settings {
+                            template = "servicenow"
+	                        short_description = "matched resources"
+                            impact = "2"
+                            urgency = "1"
+                        }
+
+	                    jira_delivery_settings {
+                            template = "jira"
+	                        description = "matched resources"
+                            project	 = "prj"
+                            summary = "short summary"
+                        }
+
+	                    symphony_delivery_settings {
+                            template = "symphony"
+
+                            recipients = [
+                        	    {
+                                  resource_owner = true
+                                },
+                        	    {
+                                  account_owner = true
+                                },
+	                        ]
+                        }
 					}
 				`,
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("stacklet_report_group.test", "email_delivery_settings.#", "1"),
-				resource.TestCheckResourceAttr("stacklet_report_group.test", "email_delivery_settings.0.template", "template.html"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "email_delivery_settings.0.template", "email"),
 				resource.TestCheckResourceAttr("stacklet_report_group.test", "email_delivery_settings.0.subject", "Matched resources"),
 				resource.TestCheckResourceAttr("stacklet_report_group.test", "email_delivery_settings.0.recipients.#", "2"),
 				resource.TestCheckResourceAttr("stacklet_report_group.test", "email_delivery_settings.0.recipients.0.resource_owner", "true"),
 				resource.TestCheckResourceAttr("stacklet_report_group.test", "email_delivery_settings.0.recipients.1.value", "user@example.com"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "slack_delivery_settings.#", "1"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "slack_delivery_settings.0.template", "slack"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "slack_delivery_settings.0.recipients.#", "1"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "slack_delivery_settings.0.recipients.0.account_owner", "true"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "teams_delivery_settings.#", "1"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "teams_delivery_settings.0.template", "teams"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "teams_delivery_settings.0.recipients.#", "1"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "teams_delivery_settings.0.recipients.0.tag", "foo"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "servicenow_delivery_settings.#", "1"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "servicenow_delivery_settings.0.template", "servicenow"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "servicenow_delivery_settings.0.short_description", "matched resources"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "servicenow_delivery_settings.0.impact", "2"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "servicenow_delivery_settings.0.urgency", "1"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "servicenow_delivery_settings.0.recipients.#", "0"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "jira_delivery_settings.#", "1"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "jira_delivery_settings.0.template", "jira"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "jira_delivery_settings.0.description", "matched resources"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "jira_delivery_settings.0.project", "prj"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "jira_delivery_settings.0.summary", "short summary"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "jira_delivery_settings.0.recipients.#", "0"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "symphony_delivery_settings.#", "1"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "symphony_delivery_settings.0.template", "symphony"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "symphony_delivery_settings.0.recipients.#", "2"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "symphony_delivery_settings.0.recipients.0.resource_owner", "true"),
+				resource.TestCheckResourceAttr("stacklet_report_group.test", "symphony_delivery_settings.0.recipients.1.account_owner", "true"),
 			),
 		},
 	}

--- a/internal/api/report_group.go
+++ b/internal/api/report_group.go
@@ -113,51 +113,56 @@ type EmailDeliverySettings struct {
 }
 
 type SlackDeliverySettings struct {
-	FirstMatchOnly *bool
-	Recipients     []Recipient
-	Template       string
+	FirstMatchOnly *bool       `json:"firstMatchOnly"`
+	Recipients     []Recipient `json:"recipients"`
+	Template       string      `json:"template"`
 }
 
 type TeamsDeliverySettings struct {
-	FirstMatchOnly *bool
-	Recipients     []Recipient
-	Template       string
+	FirstMatchOnly *bool       `json:"firstMatchOnly"`
+	Recipients     []Recipient `json:"recipients"`
+	Template       string      `json:"template"`
 }
 
 type ServiceNowDeliverySettings struct {
-	FirstMatchOnly   *bool
-	Impact           string
-	Recipients       []Recipient
-	ShortDescription string
-	Template         string
-	Urgency          string
+	FirstMatchOnly   *bool       `json:"firstMatchOnly"`
+	Impact           string      `json:"impact"`
+	Recipients       []Recipient `json:"recipients"`
+	ShortDescription string      `json:"shortDescription"`
+	Template         string      `json:"template"`
+	Urgency          string      `json:"urgency"`
 }
 
 type JiraDeliverySettings struct {
-	FirstMatchOnly *bool
-	Recipients     []Recipient
-	Template       string
-	Description    string
-	Project        string
-	Summary        string
+	FirstMatchOnly *bool       `json:"firstMatchOnly"`
+	Recipients     []Recipient `json:"recipients"`
+	Template       string      `json:"template"`
+	Description    string      `json:"description"`
+	Project        string      `json:"project"`
+	Summary        string      `json:"summary"`
 }
 
 type SymphonyDeliverySettings struct {
-	FirstMatchOnly *bool
-	Recipients     []Recipient
-	Template       string
+	FirstMatchOnly *bool       `json:"firstMatchOnly"`
+	Recipients     []Recipient `json:"recipients"`
+	Template       string      `json:"template"`
 }
 
 // ReportGroupsInput is the input to create or update a report group.
 type ReportGroupInput struct {
-	Name               string                  `json:"name"`
-	Enabled            bool                    `json:"enabled"`
-	Bindings           []string                `json:"bindings"`
-	Source             ReportSource            `json:"source"`
-	Schedule           string                  `json:"schedule"`
-	GroupBy            []string                `json:"groupBy"`
-	UseMessageSettings bool                    `json:"useMessageSettings"`
-	EmailSettings      []EmailDeliverySettings `json:"emailSettings"`
+	Name               string                       `json:"name"`
+	Enabled            bool                         `json:"enabled"`
+	Bindings           []string                     `json:"bindings"`
+	Source             ReportSource                 `json:"source"`
+	Schedule           string                       `json:"schedule"`
+	GroupBy            []string                     `json:"groupBy"`
+	UseMessageSettings bool                         `json:"useMessageSettings"`
+	EmailSettings      []EmailDeliverySettings      `json:"emailSettings"`
+	SlackSettings      []SlackDeliverySettings      `json:"slackSettings"`
+	TeamsSettings      []TeamsDeliverySettings      `json:"teamsSettings"`
+	ServiceNowSettings []ServiceNowDeliverySettings `json:"serviceNowSettings"`
+	JiraSettings       []JiraDeliverySettings       `json:"jiraSettings"`
+	SymphonySettings   []SymphonyDeliverySettings   `json:"symphonySettings"`
 }
 
 type Recipient struct {


### PR DESCRIPTION
[ENG-5559](https://stacklet.atlassian.net/browse/ENG-5559)

### what

add remaning delivery settings to the report group resource

### why

support configuring any type of delivery settings.

### testing

sandbox testing, acceptance tests

### docs

n/a


[ENG-5559]: https://stacklet.atlassian.net/browse/ENG-5559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ