### PR TITLE
fix: add missing ses_region in email profile datasource

### DIFF
--- a/docs/data-sources/configuration_profile_email.md
+++ b/docs/data-sources/configuration_profile_email.md
@@ -24,6 +24,7 @@ data "stacklet_configuration_profile_email" "example" {}
 - `from` (String) The email from field value.
 - `id` (String) The GraphQL Node ID of the configuration profile.
 - `profile` (String) The profile name.
+- `ses_region` (String) The SES region in use.
 - `smtp` (Attributes) SMTP configuration. (see [below for nested schema](#nestedatt--smtp))
 
 <a id="nestedatt--smtp"></a>

--- a/internal/api/configuration_profile.go
+++ b/internal/api/configuration_profile.go
@@ -28,7 +28,7 @@ type ConfigurationProfile struct {
 // EmailConfiguration is the configuration for email profiles.
 type EmailConfiguration struct {
 	FromEmail string
-	SesRegion *string
+	SESRegion *string            `graphql:"sesRegion"`
 	SMTP      *SMTPConfiguration `graphql:"smtp"`
 }
 

--- a/internal/models/configuration_profile_email.go
+++ b/internal/models/configuration_profile_email.go
@@ -9,10 +9,11 @@ import (
 
 // ConfigurationProfileEmailDataSource is the model for email configuration profile data sources.
 type ConfigurationProfileEmailDataSource struct {
-	ID      types.String `tfsdk:"id"`
-	Profile types.String `tfsdk:"profile"`
-	From    types.String `tfsdk:"from"`
-	SMTP    types.Object `tfsdk:"smtp"`
+	ID        types.String `tfsdk:"id"`
+	Profile   types.String `tfsdk:"profile"`
+	From      types.String `tfsdk:"from"`
+	SESRegion types.String `tfsdk:"ses_region"`
+	SMTP      types.Object `tfsdk:"smtp"`
 }
 
 // SMTP is the model for SMTP configuration.


### PR DESCRIPTION
### what

Add the missing `ses_region` attribute to email profile datasource.
Also simplify the code to get the SMTP configuration.

### why

it's provided in the API, but wasn't exposed in the model

### testing

tested in sandbox

### docs

updated
