### PR TITLE
chore: add tag-release helper to justfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,13 @@ from terraform.  To enable debug:
 2. In a separate terminal, export the value for the `TF_REATTACH_PROVIDERS`
    variable provided in the output of the previous command, and run
    `terraform`.
+
+
+## Release process
+
+1. Update the [Changelog][./CHANGELOG.md] with an entry for the new release.
+2. Create a release tag with `just tag-release X.Y.Z`.
+3. Push the tag upstream. This will start the Release workflow which creates
+   the release on GitHub and builds packages.
+4. Once the workflow has run successfully, publish the release. The Terraform
+   registry will pick up the new release automatically.

--- a/justfile
+++ b/justfile
@@ -110,3 +110,7 @@ validate-tf: build
     for dir in examples/provider examples/data-sources/* examples/resources/*; do
       validate $dir
     done
+
+# Create release tag for the specified version (without leading 'v')
+tag-release version:
+    git tag -a v{{ version }} -m 'Version {{ version }}'


### PR DESCRIPTION
### what

add just target to tag a release, add docs on how to make a release

### why

make it easier to tag a release

### testing

n/a

### docs

n/a
