### PR TITLE
fix: handle ordering in Jira projects

### DIFF
--- a/internal/acceptance_tests/configuration_profile_jira_resource_test.go
+++ b/internal/acceptance_tests/configuration_profile_jira_resource_test.go
@@ -21,10 +21,17 @@ func TestAccConfigurationProfileJiraResource(t *testing.T) {
 					api_key_wo_version = "1"
 
 					project {
-						name = "Test Project"
-						project = "TEST"
+						name = "foo"
+						project = "FOO"
 						issue_type = "Task"
 						closed_status = "Done"
+					}
+
+					project {
+						name = "bar"
+						project = "BAR"
+						issue_type = "Bug"
+						closed_status = "Fixed"
 					}
 				}
 			`,
@@ -34,19 +41,30 @@ func TestAccConfigurationProfileJiraResource(t *testing.T) {
 				resource.TestCheckResourceAttr("stacklet_configuration_profile_jira.test", "url", "https://example.atlassian.net"),
 				resource.TestCheckResourceAttr("stacklet_configuration_profile_jira.test", "user", "test@example.com"),
 				resource.TestCheckResourceAttr("stacklet_configuration_profile_jira.test", "api_key_wo_version", "1"),
-				resource.TestCheckResourceAttr("stacklet_configuration_profile_jira.test", "project.#", "1"),
-				resource.TestCheckResourceAttr("stacklet_configuration_profile_jira.test", "project.0.name", "Test Project"),
-				resource.TestCheckResourceAttr("stacklet_configuration_profile_jira.test", "project.0.project", "TEST"),
+				resource.TestCheckResourceAttr("stacklet_configuration_profile_jira.test", "project.#", "2"),
+				resource.TestCheckResourceAttr("stacklet_configuration_profile_jira.test", "project.0.name", "foo"),
+				resource.TestCheckResourceAttr("stacklet_configuration_profile_jira.test", "project.0.project", "FOO"),
 				resource.TestCheckResourceAttr("stacklet_configuration_profile_jira.test", "project.0.issue_type", "Task"),
 				resource.TestCheckResourceAttr("stacklet_configuration_profile_jira.test", "project.0.closed_status", "Done"),
+				resource.TestCheckResourceAttr("stacklet_configuration_profile_jira.test", "project.1.name", "bar"),
+				resource.TestCheckResourceAttr("stacklet_configuration_profile_jira.test", "project.1.project", "BAR"),
+				resource.TestCheckResourceAttr("stacklet_configuration_profile_jira.test", "project.1.issue_type", "Bug"),
+				resource.TestCheckResourceAttr("stacklet_configuration_profile_jira.test", "project.1.closed_status", "Fixed"),
 			),
 		},
 		// ImportState testing
 		{
-			ResourceName:            "stacklet_configuration_profile_jira.test",
-			ImportState:             true,
-			ImportStateVerify:       true,
-			ImportStateVerifyIgnore: []string{"api_key_wo", "api_key_wo_version"},
+			ResourceName:      "stacklet_configuration_profile_jira.test",
+			ImportState:       true,
+			ImportStateVerify: true,
+			ImportStateVerifyIgnore: []string{
+				"api_key_wo", "api_key_wo_version",
+				// Import returns projects in API order (alphabetical), not config order
+				"project.0.name", "project.1.name",
+				"project.0.project", "project.1.project",
+				"project.0.issue_type", "project.1.issue_type",
+				"project.0.closed_status", "project.1.closed_status",
+			},
 		},
 		// Update and Read testing
 		{

--- a/internal/acceptance_tests/recordings/TestAccConfigurationProfileJiraResource.json
+++ b/internal/acceptance_tests/recordings/TestAccConfigurationProfileJiraResource.json
@@ -1,11 +1,11 @@
 {
-  "mutation ($input:JiraConfigurationInput!){addJiraProfile(input: $input){configuration{id,profile,record{__typename,... on EmailConfiguration{fromEmail,sesRegion,smtp{server,port,ssl,username}},... on ServiceNowConfiguration{endpoint,user,issueType,closedState},... on SlackConfiguration{userFields,webhooks{name,url}},... on SymphonyConfiguration{agentDomain,serviceAccount},... on TeamsConfiguration{webhooks{name,url}},... on JiraConfiguration{url,projects{closedStatus,issueType,name,project},user,apiKey},... on ResourceOwnerConfiguration{resourceOwnerDefault: default,orgDomain,orgDomainTag,tags},... on AccountOwnersConfiguration{accountOwnersDefault: default{account,owners},orgDomain,orgDomainTag,tags}}}}}:{\"input\":{\"apiKey\":\"_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQF5oAmJkd2B6qZijP9hpSwpAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMfmlWyOxxUm/tfrmQAgEQgCpoQ8odKmZ7DKKmqP3MQtdnapwKif3ZBIziKP+GRndc72rjw6jd7unuo3Y=\",\"name\":\"jira\",\"projects\":[{\"closedStatus\":\"Closed\",\"issueType\":\"Bug\",\"name\":\"Updated Project\",\"project\":\"UPD\"}],\"scope\":\"0\",\"url\":\"https://updated.atlassian.net\",\"user\":\"updated@example.com\"}}": [
+  "mutation ($input:JiraConfigurationInput!){addJiraProfile(input: $input){configuration{id,profile,record{__typename,... on EmailConfiguration{fromEmail,sesRegion,smtp{server,port,ssl,username}},... on ServiceNowConfiguration{endpoint,user,issueType,closedState},... on SlackConfiguration{userFields,webhooks{name,url}},... on SymphonyConfiguration{agentDomain,serviceAccount},... on TeamsConfiguration{webhooks{name,url}},... on JiraConfiguration{url,projects{closedStatus,issueType,name,project},user,apiKey},... on ResourceOwnerConfiguration{resourceOwnerDefault: default,orgDomain,orgDomainTag,tags},... on AccountOwnersConfiguration{accountOwnersDefault: default{account,owners},orgDomain,orgDomainTag,tags}}}}}:{\"input\":{\"apiKey\":\"_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQHILsdr5Mq4VSSV83nRXiWZAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMb0Rh31/HgDmGxi0pAgEQgCpWCYqN3zGd62DYAgXg9HitgIMpPNqCe00oWpSvgIU00GxMKL/FTglRNg0=\",\"name\":\"jira\",\"projects\":[{\"closedStatus\":\"Closed\",\"issueType\":\"Bug\",\"name\":\"Updated Project\",\"project\":\"UPD\"}],\"scope\":\"0\",\"url\":\"https://updated.atlassian.net\",\"user\":\"updated@example.com\"}}": [
     {
       "request": {
         "query": "mutation ($input:JiraConfigurationInput!){addJiraProfile(input: $input){configuration{id,profile,record{__typename,... on EmailConfiguration{fromEmail,sesRegion,smtp{server,port,ssl,username}},... on ServiceNowConfiguration{endpoint,user,issueType,closedState},... on SlackConfiguration{userFields,webhooks{name,url}},... on SymphonyConfiguration{agentDomain,serviceAccount},... on TeamsConfiguration{webhooks{name,url}},... on JiraConfiguration{url,projects{closedStatus,issueType,name,project},user,apiKey},... on ResourceOwnerConfiguration{resourceOwnerDefault: default,orgDomain,orgDomainTag,tags},... on AccountOwnersConfiguration{accountOwnersDefault: default{account,owners},orgDomain,orgDomainTag,tags}}}}}",
         "variables": {
           "input": {
-            "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQF5oAmJkd2B6qZijP9hpSwpAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMfmlWyOxxUm/tfrmQAgEQgCpoQ8odKmZ7DKKmqP3MQtdnapwKif3ZBIziKP+GRndc72rjw6jd7unuo3Y=",
+            "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQHILsdr5Mq4VSSV83nRXiWZAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMb0Rh31/HgDmGxi0pAgEQgCpWCYqN3zGd62DYAgXg9HitgIMpPNqCe00oWpSvgIU00GxMKL/FTglRNg0=",
             "name": "jira",
             "projects": [
               {
@@ -29,7 +29,7 @@
               "profile": "jira",
               "record": {
                 "__typename": "JiraConfiguration",
-                "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQF5oAmJkd2B6qZijP9hpSwpAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMfmlWyOxxUm/tfrmQAgEQgCpoQ8odKmZ7DKKmqP3MQtdnapwKif3ZBIziKP+GRndc72rjw6jd7unuo3Y=",
+                "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQHILsdr5Mq4VSSV83nRXiWZAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMb0Rh31/HgDmGxi0pAgEQgCpWCYqN3zGd62DYAgXg9HitgIMpPNqCe00oWpSvgIU00GxMKL/FTglRNg0=",
                 "projects": [
                   {
                     "closedStatus": "Closed",
@@ -47,7 +47,7 @@
       }
     }
   ],
-  "mutation ($input:JiraConfigurationInput!){addJiraProfile(input: $input){configuration{id,profile,record{__typename,... on EmailConfiguration{fromEmail,sesRegion,smtp{server,port,ssl,username}},... on ServiceNowConfiguration{endpoint,user,issueType,closedState},... on SlackConfiguration{userFields,webhooks{name,url}},... on SymphonyConfiguration{agentDomain,serviceAccount},... on TeamsConfiguration{webhooks{name,url}},... on JiraConfiguration{url,projects{closedStatus,issueType,name,project},user,apiKey},... on ResourceOwnerConfiguration{resourceOwnerDefault: default,orgDomain,orgDomainTag,tags},... on AccountOwnersConfiguration{accountOwnersDefault: default{account,owners},orgDomain,orgDomainTag,tags}}}}}:{\"input\":{\"apiKey\":\"initial-api-key\",\"name\":\"jira\",\"projects\":[{\"closedStatus\":\"Done\",\"issueType\":\"Task\",\"name\":\"Test Project\",\"project\":\"TEST\"}],\"scope\":\"0\",\"url\":\"https://example.atlassian.net\",\"user\":\"test@example.com\"}}": [
+  "mutation ($input:JiraConfigurationInput!){addJiraProfile(input: $input){configuration{id,profile,record{__typename,... on EmailConfiguration{fromEmail,sesRegion,smtp{server,port,ssl,username}},... on ServiceNowConfiguration{endpoint,user,issueType,closedState},... on SlackConfiguration{userFields,webhooks{name,url}},... on SymphonyConfiguration{agentDomain,serviceAccount},... on TeamsConfiguration{webhooks{name,url}},... on JiraConfiguration{url,projects{closedStatus,issueType,name,project},user,apiKey},... on ResourceOwnerConfiguration{resourceOwnerDefault: default,orgDomain,orgDomainTag,tags},... on AccountOwnersConfiguration{accountOwnersDefault: default{account,owners},orgDomain,orgDomainTag,tags}}}}}:{\"input\":{\"apiKey\":\"initial-api-key\",\"name\":\"jira\",\"projects\":[{\"closedStatus\":\"Done\",\"issueType\":\"Task\",\"name\":\"foo\",\"project\":\"FOO\"},{\"closedStatus\":\"Fixed\",\"issueType\":\"Bug\",\"name\":\"bar\",\"project\":\"BAR\"}],\"scope\":\"0\",\"url\":\"https://example.atlassian.net\",\"user\":\"test@example.com\"}}": [
     {
       "request": {
         "query": "mutation ($input:JiraConfigurationInput!){addJiraProfile(input: $input){configuration{id,profile,record{__typename,... on EmailConfiguration{fromEmail,sesRegion,smtp{server,port,ssl,username}},... on ServiceNowConfiguration{endpoint,user,issueType,closedState},... on SlackConfiguration{userFields,webhooks{name,url}},... on SymphonyConfiguration{agentDomain,serviceAccount},... on TeamsConfiguration{webhooks{name,url}},... on JiraConfiguration{url,projects{closedStatus,issueType,name,project},user,apiKey},... on ResourceOwnerConfiguration{resourceOwnerDefault: default,orgDomain,orgDomainTag,tags},... on AccountOwnersConfiguration{accountOwnersDefault: default{account,owners},orgDomain,orgDomainTag,tags}}}}}",
@@ -59,8 +59,14 @@
               {
                 "closedStatus": "Done",
                 "issueType": "Task",
-                "name": "Test Project",
-                "project": "TEST"
+                "name": "foo",
+                "project": "FOO"
+              },
+              {
+                "closedStatus": "Fixed",
+                "issueType": "Bug",
+                "name": "bar",
+                "project": "BAR"
               }
             ],
             "scope": "0",
@@ -77,13 +83,19 @@
               "profile": "jira",
               "record": {
                 "__typename": "JiraConfiguration",
-                "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQF5oAmJkd2B6qZijP9hpSwpAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMfmlWyOxxUm/tfrmQAgEQgCpoQ8odKmZ7DKKmqP3MQtdnapwKif3ZBIziKP+GRndc72rjw6jd7unuo3Y=",
+                "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQHILsdr5Mq4VSSV83nRXiWZAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMb0Rh31/HgDmGxi0pAgEQgCpWCYqN3zGd62DYAgXg9HitgIMpPNqCe00oWpSvgIU00GxMKL/FTglRNg0=",
                 "projects": [
+                  {
+                    "closedStatus": "Fixed",
+                    "issueType": "Bug",
+                    "name": "bar",
+                    "project": "BAR"
+                  },
                   {
                     "closedStatus": "Done",
                     "issueType": "Task",
-                    "name": "Test Project",
-                    "project": "TEST"
+                    "name": "foo",
+                    "project": "FOO"
                   }
                 ],
                 "url": "https://example.atlassian.net",
@@ -127,13 +139,19 @@
             "profile": "jira",
             "record": {
               "__typename": "JiraConfiguration",
-              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQF5oAmJkd2B6qZijP9hpSwpAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMfmlWyOxxUm/tfrmQAgEQgCpoQ8odKmZ7DKKmqP3MQtdnapwKif3ZBIziKP+GRndc72rjw6jd7unuo3Y=",
+              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQHILsdr5Mq4VSSV83nRXiWZAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMb0Rh31/HgDmGxi0pAgEQgCpWCYqN3zGd62DYAgXg9HitgIMpPNqCe00oWpSvgIU00GxMKL/FTglRNg0=",
               "projects": [
+                {
+                  "closedStatus": "Fixed",
+                  "issueType": "Bug",
+                  "name": "bar",
+                  "project": "BAR"
+                },
                 {
                   "closedStatus": "Done",
                   "issueType": "Task",
-                  "name": "Test Project",
-                  "project": "TEST"
+                  "name": "foo",
+                  "project": "FOO"
                 }
               ],
               "url": "https://example.atlassian.net",
@@ -158,13 +176,19 @@
             "profile": "jira",
             "record": {
               "__typename": "JiraConfiguration",
-              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQF5oAmJkd2B6qZijP9hpSwpAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMfmlWyOxxUm/tfrmQAgEQgCpoQ8odKmZ7DKKmqP3MQtdnapwKif3ZBIziKP+GRndc72rjw6jd7unuo3Y=",
+              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQHILsdr5Mq4VSSV83nRXiWZAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMb0Rh31/HgDmGxi0pAgEQgCpWCYqN3zGd62DYAgXg9HitgIMpPNqCe00oWpSvgIU00GxMKL/FTglRNg0=",
               "projects": [
+                {
+                  "closedStatus": "Fixed",
+                  "issueType": "Bug",
+                  "name": "bar",
+                  "project": "BAR"
+                },
                 {
                   "closedStatus": "Done",
                   "issueType": "Task",
-                  "name": "Test Project",
-                  "project": "TEST"
+                  "name": "foo",
+                  "project": "FOO"
                 }
               ],
               "url": "https://example.atlassian.net",
@@ -189,13 +213,19 @@
             "profile": "jira",
             "record": {
               "__typename": "JiraConfiguration",
-              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQF5oAmJkd2B6qZijP9hpSwpAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMfmlWyOxxUm/tfrmQAgEQgCpoQ8odKmZ7DKKmqP3MQtdnapwKif3ZBIziKP+GRndc72rjw6jd7unuo3Y=",
+              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQHILsdr5Mq4VSSV83nRXiWZAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMb0Rh31/HgDmGxi0pAgEQgCpWCYqN3zGd62DYAgXg9HitgIMpPNqCe00oWpSvgIU00GxMKL/FTglRNg0=",
               "projects": [
+                {
+                  "closedStatus": "Fixed",
+                  "issueType": "Bug",
+                  "name": "bar",
+                  "project": "BAR"
+                },
                 {
                   "closedStatus": "Done",
                   "issueType": "Task",
-                  "name": "Test Project",
-                  "project": "TEST"
+                  "name": "foo",
+                  "project": "FOO"
                 }
               ],
               "url": "https://example.atlassian.net",
@@ -220,7 +250,7 @@
             "profile": "jira",
             "record": {
               "__typename": "JiraConfiguration",
-              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQF5oAmJkd2B6qZijP9hpSwpAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMfmlWyOxxUm/tfrmQAgEQgCpoQ8odKmZ7DKKmqP3MQtdnapwKif3ZBIziKP+GRndc72rjw6jd7unuo3Y=",
+              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQHILsdr5Mq4VSSV83nRXiWZAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMb0Rh31/HgDmGxi0pAgEQgCpWCYqN3zGd62DYAgXg9HitgIMpPNqCe00oWpSvgIU00GxMKL/FTglRNg0=",
               "projects": [
                 {
                   "closedStatus": "Closed",

--- a/internal/acceptance_tests/recordings/TestAccConfigurationProfileJiraResource_APIKeyChange.json
+++ b/internal/acceptance_tests/recordings/TestAccConfigurationProfileJiraResource_APIKeyChange.json
@@ -29,7 +29,7 @@
               "profile": "jira",
               "record": {
                 "__typename": "JiraConfiguration",
-                "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQF+SIuNTQM2MNcfAG+3byJ3AAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMktN7F9rj+b9z6qwrAgEQgCoYmPh4AwgeHVXUS0hcXmLOEUeLv/57Y/WSCR3igCIjTmueF000wQ6Yh9w=",
+                "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQFRsTofbmE/oxgXbJZhs0zvAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMwI7ZhIuGT/4Hf5nUAgEQgCohqSduL5Aw51s181ccAh++w7luHZcmFmpk8JgDLgzjYT/888ly1YGBEu8=",
                 "projects": [
                   {
                     "closedStatus": "Done",
@@ -77,7 +77,7 @@
               "profile": "jira",
               "record": {
                 "__typename": "JiraConfiguration",
-                "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQGHhHizisaVyjWG7kBvPbbiAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM1M6VXDDA5cpuifvXAgEQgCo2H+EcjoN5BMTxyXZWzifs35RHD3xSfGnvBPKBM1Z4zw66xyHnwuKhjRc=",
+                "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQFNo3B54PEnsyVIfHot14I1AAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMmtBIHvK9AXhdmShDAgEQgCocOmGncIc5c6O51Danmb0vpQFhlFLx6ORvAQM3hmtalnAbjaBn/GPa5DA=",
                 "projects": [
                   {
                     "closedStatus": "Done",
@@ -127,7 +127,7 @@
             "profile": "jira",
             "record": {
               "__typename": "JiraConfiguration",
-              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQF+SIuNTQM2MNcfAG+3byJ3AAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMktN7F9rj+b9z6qwrAgEQgCoYmPh4AwgeHVXUS0hcXmLOEUeLv/57Y/WSCR3igCIjTmueF000wQ6Yh9w=",
+              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQFRsTofbmE/oxgXbJZhs0zvAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMwI7ZhIuGT/4Hf5nUAgEQgCohqSduL5Aw51s181ccAh++w7luHZcmFmpk8JgDLgzjYT/888ly1YGBEu8=",
               "projects": [
                 {
                   "closedStatus": "Done",
@@ -158,7 +158,7 @@
             "profile": "jira",
             "record": {
               "__typename": "JiraConfiguration",
-              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQF+SIuNTQM2MNcfAG+3byJ3AAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMktN7F9rj+b9z6qwrAgEQgCoYmPh4AwgeHVXUS0hcXmLOEUeLv/57Y/WSCR3igCIjTmueF000wQ6Yh9w=",
+              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQFRsTofbmE/oxgXbJZhs0zvAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMwI7ZhIuGT/4Hf5nUAgEQgCohqSduL5Aw51s181ccAh++w7luHZcmFmpk8JgDLgzjYT/888ly1YGBEu8=",
               "projects": [
                 {
                   "closedStatus": "Done",
@@ -189,7 +189,7 @@
             "profile": "jira",
             "record": {
               "__typename": "JiraConfiguration",
-              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQF+SIuNTQM2MNcfAG+3byJ3AAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMktN7F9rj+b9z6qwrAgEQgCoYmPh4AwgeHVXUS0hcXmLOEUeLv/57Y/WSCR3igCIjTmueF000wQ6Yh9w=",
+              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQFRsTofbmE/oxgXbJZhs0zvAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMwI7ZhIuGT/4Hf5nUAgEQgCohqSduL5Aw51s181ccAh++w7luHZcmFmpk8JgDLgzjYT/888ly1YGBEu8=",
               "projects": [
                 {
                   "closedStatus": "Done",
@@ -220,7 +220,7 @@
             "profile": "jira",
             "record": {
               "__typename": "JiraConfiguration",
-              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQF+SIuNTQM2MNcfAG+3byJ3AAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMktN7F9rj+b9z6qwrAgEQgCoYmPh4AwgeHVXUS0hcXmLOEUeLv/57Y/WSCR3igCIjTmueF000wQ6Yh9w=",
+              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQFRsTofbmE/oxgXbJZhs0zvAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMwI7ZhIuGT/4Hf5nUAgEQgCohqSduL5Aw51s181ccAh++w7luHZcmFmpk8JgDLgzjYT/888ly1YGBEu8=",
               "projects": [
                 {
                   "closedStatus": "Done",
@@ -251,7 +251,7 @@
             "profile": "jira",
             "record": {
               "__typename": "JiraConfiguration",
-              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQGHhHizisaVyjWG7kBvPbbiAAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM1M6VXDDA5cpuifvXAgEQgCo2H+EcjoN5BMTxyXZWzifs35RHD3xSfGnvBPKBM1Z4zw66xyHnwuKhjRc=",
+              "apiKey": "_encrypted:AQICAHh4ux78bAs/X3yYBg/TwgPXGB46MhYMn/VlwsH+BGTJoQFNo3B54PEnsyVIfHot14I1AAAAbTBrBgkqhkiG9w0BBwagXjBcAgEAMFcGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMmtBIHvK9AXhdmShDAgEQgCocOmGncIc5c6O51Danmb0vpQFhlFLx6ORvAQM3hmtalnAbjaBn/GPa5DA=",
               "projects": [
                 {
                   "closedStatus": "Done",

--- a/internal/datasources/configuration_profile_jira.go
+++ b/internal/datasources/configuration_profile_jira.go
@@ -113,7 +113,7 @@ func (d *configurationProfileJiraDataSource) Read(ctx context.Context, req datas
 	data.APIKey = types.StringValue(config.Record.JiraConfiguration.APIKey)
 
 	updater := modelupdate.NewConfigurationProfileUpdater(*config)
-	projects, diags := updater.JiraProjects()
+	projects, diags := updater.JiraProjects(nil)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/resources/configuration_profile_jira.go
+++ b/internal/resources/configuration_profile_jira.go
@@ -242,8 +242,11 @@ func (r configurationProfileJiraResource) updateJiraModel(m *models.Configuratio
 	m.User = types.StringValue(jiraConfig.User)
 	m.APIKey = types.StringValue(jiraConfig.APIKey)
 
+	// get the current names ordering to preserve it in the updated projects block
+	names := models.ListItemsIdentifiers(m.Projects, "name")
+
 	updater := modelupdate.NewConfigurationProfileUpdater(*config)
-	projects, diags := updater.JiraProjects()
+	projects, diags := updater.JiraProjects(names)
 	if diags.HasError() {
 		return diags
 	}


### PR DESCRIPTION
### what

preserve order specified in config/plan for Jira projects

### why

since projects are returned in alphabetical order, they need to be rearranged
to match what terraform expects

### testing

updated tests

### docs

n/a
