### PR TITLE
chore: add examples for import blocks

### DIFF
--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -94,6 +94,15 @@ resource "stacklet_account" "tencent_prod" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_account.example
+  id = "$cloud_provider:$key"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/account_discovery_aws.md
+++ b/docs/resources/account_discovery_aws.md
@@ -46,6 +46,15 @@ resource "stacklet_account_discovery_aws" "example" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_account_discovery_aws.example
+  id = "$name"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/account_discovery_azure.md
+++ b/docs/resources/account_discovery_azure.md
@@ -47,6 +47,15 @@ resource "stacklet_account_discovery_azure" "example" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_account_discovery_azure.example
+  id = "$name"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/account_discovery_gcp.md
+++ b/docs/resources/account_discovery_gcp.md
@@ -68,6 +68,15 @@ resource "stacklet_account_discovery_gcp" "example" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_account_discovery_gcp.example
+  id = "$name"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/account_group.md
+++ b/docs/resources/account_group.md
@@ -51,8 +51,17 @@ resource "stacklet_account_group" "development" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_account_group.example
+  id = "$uuid"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import stacket_account_group.example $uuid
+terraform import stacklet_account_group.example $uuid
 ```

--- a/docs/resources/account_group_mapping.md
+++ b/docs/resources/account_group_mapping.md
@@ -59,6 +59,15 @@ resource "stacklet_account_group_mapping" "prod_accounts" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_account_group_mapping.example
+  id = "$group_uuid:$account_key"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/binding.md
+++ b/docs/resources/binding.md
@@ -120,8 +120,17 @@ Optional:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_binding.example
+  id = "$uuid"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import stacket_binding.example $uuid
+terraform import stacklet_binding.example $uuid
 ```

--- a/docs/resources/configuration_profile_account_owners.md
+++ b/docs/resources/configuration_profile_account_owners.md
@@ -64,6 +64,15 @@ Required:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_configuration_profile_account_owners.example
+  id = "ignored" # the resource ID is ignored since it's global
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/configuration_profile_email.md
+++ b/docs/resources/configuration_profile_email.md
@@ -78,6 +78,15 @@ Read-Only:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_configuration_profile_email.example
+  id = "ignored" # the resource ID is ignored since it's global
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/configuration_profile_jira.md
+++ b/docs/resources/configuration_profile_jira.md
@@ -75,6 +75,15 @@ Required:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_configuration_profile_jira.example
+  id = "ignored" # the resource ID is ignored since it's global
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/configuration_profile_resource_owner.md
+++ b/docs/resources/configuration_profile_resource_owner.md
@@ -44,6 +44,15 @@ resource "stacklet_configuration_profile_resource_owner" "example" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_configuration_profile_resource_owner.example
+  id = "ignored" # the resource ID is ignored since it's global
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/configuration_profile_servicenow.md
+++ b/docs/resources/configuration_profile_servicenow.md
@@ -52,6 +52,15 @@ resource "stacklet_configuration_profile_servicenow" "example" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_configuration_profile_servicenow.example
+  id = "ignored" # the resource ID is ignored since it's global
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/configuration_profile_slack.md
+++ b/docs/resources/configuration_profile_slack.md
@@ -70,6 +70,15 @@ Read-Only:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_configuration_profile_slack.example
+  id = "ignored" # the resource ID is ignored since it's global
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/configuration_profile_symphony.md
+++ b/docs/resources/configuration_profile_symphony.md
@@ -47,6 +47,15 @@ resource "stacklet_configuration_profile_symphony" "example" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_configuration_profile_symphony.example
+  id = "ignored" # the resource ID is ignored since it's global
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/configuration_profile_teams.md
+++ b/docs/resources/configuration_profile_teams.md
@@ -64,6 +64,15 @@ Read-Only:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_configuration_profile_teams.example
+  id = "ignored" # the resource ID is ignored since it's global
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/notification_template.md
+++ b/docs/resources/notification_template.md
@@ -66,6 +66,15 @@ EOT
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_notification_template.example
+  id = "$name"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/policy_collection.md
+++ b/docs/resources/policy_collection.md
@@ -79,6 +79,15 @@ Read-Only:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_account.example
+  id = "$collection_uuid"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/policy_collection_mapping.md
+++ b/docs/resources/policy_collection_mapping.md
@@ -38,6 +38,15 @@ resource "stacklet_policy_collection_mapping" "example" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_policy_collection_mapping.example
+  id = "$policy_collection_uuid:$policy_uuid"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/report_group.md
+++ b/docs/resources/report_group.md
@@ -220,6 +220,15 @@ Optional:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_report_group.example
+  id = "$name"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -89,8 +89,17 @@ resource "stacklet_repository" "example_codecommit" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+import {
+  to = stacklet_repository.example
+  id = "$url"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import stacket_repository.example $url
+terraform import stacklet_repository.example $url
 ```

--- a/examples/resources/stacklet_account/import-by-string-id.tf
+++ b/examples/resources/stacklet_account/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_account.example
+  id = "$cloud_provider:$key"
+}

--- a/examples/resources/stacklet_account_discovery_aws/import-by-string-id.tf
+++ b/examples/resources/stacklet_account_discovery_aws/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_account_discovery_aws.example
+  id = "$name"
+}

--- a/examples/resources/stacklet_account_discovery_azure/import-by-string-id.tf
+++ b/examples/resources/stacklet_account_discovery_azure/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_account_discovery_azure.example
+  id = "$name"
+}

--- a/examples/resources/stacklet_account_discovery_gcp/import-by-string-id.tf
+++ b/examples/resources/stacklet_account_discovery_gcp/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_account_discovery_gcp.example
+  id = "$name"
+}

--- a/examples/resources/stacklet_account_group/import-by-string-id.tf
+++ b/examples/resources/stacklet_account_group/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_account_group.example
+  id = "$uuid"
+}

--- a/examples/resources/stacklet_account_group/import.sh
+++ b/examples/resources/stacklet_account_group/import.sh
@@ -1,1 +1,1 @@
-terraform import stacket_account_group.example $uuid
+terraform import stacklet_account_group.example $uuid

--- a/examples/resources/stacklet_account_group_mapping/import-by-string-id.tf
+++ b/examples/resources/stacklet_account_group_mapping/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_account_group_mapping.example
+  id = "$group_uuid:$account_key"
+}

--- a/examples/resources/stacklet_binding/import-by-string-id.tf
+++ b/examples/resources/stacklet_binding/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_binding.example
+  id = "$uuid"
+}

--- a/examples/resources/stacklet_binding/import.sh
+++ b/examples/resources/stacklet_binding/import.sh
@@ -1,1 +1,1 @@
-terraform import stacket_binding.example $uuid
+terraform import stacklet_binding.example $uuid

--- a/examples/resources/stacklet_configuration_profile_account_owners/import-by-string-id.tf
+++ b/examples/resources/stacklet_configuration_profile_account_owners/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_configuration_profile_account_owners.example
+  id = "ignored" # the resource ID is ignored since it's global
+}

--- a/examples/resources/stacklet_configuration_profile_email/import-by-string-id.tf
+++ b/examples/resources/stacklet_configuration_profile_email/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_configuration_profile_email.example
+  id = "ignored" # the resource ID is ignored since it's global
+}

--- a/examples/resources/stacklet_configuration_profile_jira/import-by-string-id.tf
+++ b/examples/resources/stacklet_configuration_profile_jira/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_configuration_profile_jira.example
+  id = "ignored" # the resource ID is ignored since it's global
+}

--- a/examples/resources/stacklet_configuration_profile_resource_owner/import-by-string-id.tf
+++ b/examples/resources/stacklet_configuration_profile_resource_owner/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_configuration_profile_resource_owner.example
+  id = "ignored" # the resource ID is ignored since it's global
+}

--- a/examples/resources/stacklet_configuration_profile_servicenow/import-by-string-id.tf
+++ b/examples/resources/stacklet_configuration_profile_servicenow/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_configuration_profile_servicenow.example
+  id = "ignored" # the resource ID is ignored since it's global
+}

--- a/examples/resources/stacklet_configuration_profile_slack/import-by-string-id.tf
+++ b/examples/resources/stacklet_configuration_profile_slack/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_configuration_profile_slack.example
+  id = "ignored" # the resource ID is ignored since it's global
+}

--- a/examples/resources/stacklet_configuration_profile_symphony/import-by-string-id.tf
+++ b/examples/resources/stacklet_configuration_profile_symphony/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_configuration_profile_symphony.example
+  id = "ignored" # the resource ID is ignored since it's global
+}

--- a/examples/resources/stacklet_configuration_profile_teams/import-by-string-id.tf
+++ b/examples/resources/stacklet_configuration_profile_teams/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_configuration_profile_teams.example
+  id = "ignored" # the resource ID is ignored since it's global
+}

--- a/examples/resources/stacklet_notification_template/import-by-string-id.tf
+++ b/examples/resources/stacklet_notification_template/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_notification_template.example
+  id = "$name"
+}

--- a/examples/resources/stacklet_policy_collection/import-by-string-id.tf
+++ b/examples/resources/stacklet_policy_collection/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_account.example
+  id = "$collection_uuid"
+}

--- a/examples/resources/stacklet_policy_collection_mapping/import-by-string-id.tf
+++ b/examples/resources/stacklet_policy_collection_mapping/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_policy_collection_mapping.example
+  id = "$policy_collection_uuid:$policy_uuid"
+}

--- a/examples/resources/stacklet_report_group/import-by-string-id.tf
+++ b/examples/resources/stacklet_report_group/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_report_group.example
+  id = "$name"
+}

--- a/examples/resources/stacklet_repository/import-by-string-id.tf
+++ b/examples/resources/stacklet_repository/import-by-string-id.tf
@@ -1,0 +1,4 @@
+import {
+  to = stacklet_repository.example
+  id = "$url"
+}

--- a/examples/resources/stacklet_repository/import.sh
+++ b/examples/resources/stacklet_repository/import.sh
@@ -1,1 +1,1 @@
-terraform import stacket_repository.example $url
+terraform import stacklet_repository.example $url


### PR DESCRIPTION
### what

add examples for import blocks, in addition to the import command

### why

show how resources are imported with blocks

### testing

n/a

### docs

this is a docs change
