### PR TITLE
fix: remove RoleAssignment from GrantRoleAssignmentPayload to fix decode error (ENG-7561)

### DIFF
--- a/internal/acceptance_tests/recordings/TestAccRoleAssignmentResource.json
+++ b/internal/acceptance_tests/recordings/TestAccRoleAssignmentResource.json
@@ -34,10 +34,10 @@
       }
     }
   ],
-  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},revoke{errorMessage,removed{id}}}}:{\"input\":{\"grant\":[{\"principal\":\"user:1\",\"roleName\":\"editor\",\"target\":\"account-group:1c5f4480-9e28-4548-8213-b0ed1c65c0aa\"}]}}": [
+  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage},revoke{errorMessage,removed{id}}}}:{\"input\":{\"grant\":[{\"principal\":\"user:1\",\"roleName\":\"editor\",\"target\":\"account-group:1c5f4480-9e28-4548-8213-b0ed1c65c0aa\"}]}}": [
     {
       "request": {
-        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},revoke{errorMessage,removed{id}}}}",
+        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage},revoke{errorMessage,removed{id}}}}",
         "variables": {
           "input": {
             "grant": [
@@ -55,27 +55,7 @@
           "updateRoleAssignment": {
             "grant": [
               {
-                "errorMessage": null,
-                "roleAssignment": {
-                  "id": "WyJyb2xlX2Fzc2lnbm1lbnQiLCAiMTA5Il0=",
-                  "principal": {
-                    "roleAssignmentPrincipal": "user:1"
-                  },
-                  "role": {
-                    "id": "WyJyb2xlIiwgIjQiXQ==",
-                    "name": "editor",
-                    "permissions": [
-                      "EDIT",
-                      "REMOVE",
-                      "VIEW",
-                      "VIEW_ACL"
-                    ],
-                    "system": true
-                  },
-                  "target": {
-                    "roleAssignmentTarget": "account-group:1c5f4480-9e28-4548-8213-b0ed1c65c0aa"
-                  }
-                }
+                "errorMessage": null
               }
             ],
             "revoke": []
@@ -84,10 +64,10 @@
       }
     }
   ],
-  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},revoke{errorMessage,removed{id}}}}:{\"input\":{\"grant\":[{\"principal\":\"user:1\",\"roleName\":\"viewer\",\"target\":\"account-group:1c5f4480-9e28-4548-8213-b0ed1c65c0aa\"}]}}": [
+  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage},revoke{errorMessage,removed{id}}}}:{\"input\":{\"grant\":[{\"principal\":\"user:1\",\"roleName\":\"viewer\",\"target\":\"account-group:1c5f4480-9e28-4548-8213-b0ed1c65c0aa\"}]}}": [
     {
       "request": {
-        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},revoke{errorMessage,removed{id}}}}",
+        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage},revoke{errorMessage,removed{id}}}}",
         "variables": {
           "input": {
             "grant": [
@@ -105,24 +85,7 @@
           "updateRoleAssignment": {
             "grant": [
               {
-                "errorMessage": null,
-                "roleAssignment": {
-                  "id": "WyJyb2xlX2Fzc2lnbm1lbnQiLCAiMTA4Il0=",
-                  "principal": {
-                    "roleAssignmentPrincipal": "user:1"
-                  },
-                  "role": {
-                    "id": "WyJyb2xlIiwgIjMiXQ==",
-                    "name": "viewer",
-                    "permissions": [
-                      "VIEW"
-                    ],
-                    "system": true
-                  },
-                  "target": {
-                    "roleAssignmentTarget": "account-group:1c5f4480-9e28-4548-8213-b0ed1c65c0aa"
-                  }
-                }
+                "errorMessage": null
               }
             ],
             "revoke": []
@@ -131,10 +94,10 @@
       }
     }
   ],
-  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},revoke{errorMessage,removed{id}}}}:{\"input\":{\"revoke\":[{\"principal\":\"user:1\",\"roleName\":\"editor\",\"target\":\"account-group:1c5f4480-9e28-4548-8213-b0ed1c65c0aa\"}]}}": [
+  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage},revoke{errorMessage,removed{id}}}}:{\"input\":{\"revoke\":[{\"principal\":\"user:1\",\"roleName\":\"editor\",\"target\":\"account-group:1c5f4480-9e28-4548-8213-b0ed1c65c0aa\"}]}}": [
     {
       "request": {
-        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},revoke{errorMessage,removed{id}}}}",
+        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage},revoke{errorMessage,removed{id}}}}",
         "variables": {
           "input": {
             "revoke": [
@@ -164,10 +127,10 @@
       }
     }
   ],
-  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},revoke{errorMessage,removed{id}}}}:{\"input\":{\"revoke\":[{\"principal\":\"user:1\",\"roleName\":\"viewer\",\"target\":\"account-group:1c5f4480-9e28-4548-8213-b0ed1c65c0aa\"}]}}": [
+  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage},revoke{errorMessage,removed{id}}}}:{\"input\":{\"revoke\":[{\"principal\":\"user:1\",\"roleName\":\"viewer\",\"target\":\"account-group:1c5f4480-9e28-4548-8213-b0ed1c65c0aa\"}]}}": [
     {
       "request": {
-        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},revoke{errorMessage,removed{id}}}}",
+        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage},revoke{errorMessage,removed{id}}}}",
         "variables": {
           "input": {
             "revoke": [

--- a/internal/acceptance_tests/recordings/TestAccRoleAssignmentResource_AccountGroup.json
+++ b/internal/acceptance_tests/recordings/TestAccRoleAssignmentResource_AccountGroup.json
@@ -34,10 +34,10 @@
       }
     }
   ],
-  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},revoke{errorMessage,removed{id}}}}:{\"input\":{\"grant\":[{\"principal\":\"user:1\",\"roleName\":\"viewer\",\"target\":\"account-group:f3df013b-9937-4fe5-bff3-ee35262e4da5\"}]}}": [
+  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage},revoke{errorMessage,removed{id}}}}:{\"input\":{\"grant\":[{\"principal\":\"user:1\",\"roleName\":\"viewer\",\"target\":\"account-group:f3df013b-9937-4fe5-bff3-ee35262e4da5\"}]}}": [
     {
       "request": {
-        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},revoke{errorMessage,removed{id}}}}",
+        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage},revoke{errorMessage,removed{id}}}}",
         "variables": {
           "input": {
             "grant": [
@@ -55,24 +55,7 @@
           "updateRoleAssignment": {
             "grant": [
               {
-                "errorMessage": null,
-                "roleAssignment": {
-                  "id": "WyJyb2xlX2Fzc2lnbm1lbnQiLCAiMTExIl0=",
-                  "principal": {
-                    "roleAssignmentPrincipal": "user:1"
-                  },
-                  "role": {
-                    "id": "WyJyb2xlIiwgIjMiXQ==",
-                    "name": "viewer",
-                    "permissions": [
-                      "VIEW"
-                    ],
-                    "system": true
-                  },
-                  "target": {
-                    "roleAssignmentTarget": "account-group:f3df013b-9937-4fe5-bff3-ee35262e4da5"
-                  }
-                }
+                "errorMessage": null
               }
             ],
             "revoke": []
@@ -81,10 +64,10 @@
       }
     }
   ],
-  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},revoke{errorMessage,removed{id}}}}:{\"input\":{\"revoke\":[{\"principal\":\"user:1\",\"roleName\":\"viewer\",\"target\":\"account-group:f3df013b-9937-4fe5-bff3-ee35262e4da5\"}]}}": [
+  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage},revoke{errorMessage,removed{id}}}}:{\"input\":{\"revoke\":[{\"principal\":\"user:1\",\"roleName\":\"viewer\",\"target\":\"account-group:f3df013b-9937-4fe5-bff3-ee35262e4da5\"}]}}": [
     {
       "request": {
-        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},revoke{errorMessage,removed{id}}}}",
+        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage},revoke{errorMessage,removed{id}}}}",
         "variables": {
           "input": {
             "revoke": [

--- a/internal/api/role_assignment.go
+++ b/internal/api/role_assignment.go
@@ -78,16 +78,7 @@ type UpdateRoleAssignmentInput struct {
 
 // GrantRoleAssignmentPayload represents the result of granting a role assignment.
 type GrantRoleAssignmentPayload struct {
-	ErrorMessage   *string
-	RoleAssignment *RoleAssignment
-}
-
-func (p GrantRoleAssignmentPayload) Error() string {
-	if p.ErrorMessage == nil {
-		return ""
-	}
-
-	return *p.ErrorMessage
+	ErrorMessage *string
 }
 
 // RevokeRoleAssignmentPayload represents the result of revoking a role assignment.
@@ -145,20 +136,14 @@ func (r roleAssignmentAPI) Create(ctx context.Context, roleName string, principa
 			return nil, NewAPIError(fmt.Errorf("failed to grant role assignment: %s", *grantPayload.ErrorMessage))
 		}
 
-		// The ID returned from the mutation may not match the actual persisted assignment
-		// Query to get the actual role assignment by the unique (role, principal, target) combination
-		if grantPayload.RoleAssignment != nil {
-			// List assignments filtered by target and principal, then find the matching role
-			assignments, err := r.List(ctx, &target, &principal)
-			if err != nil {
-				return nil, err
-			}
+		assignments, err := r.List(ctx, &target, &principal)
+		if err != nil {
+			return nil, err
+		}
 
-			// Find the assignment with the matching role name
-			for _, assignment := range assignments {
-				if assignment.Role.Name == roleName {
-					return &assignment, nil
-				}
+		for _, assignment := range assignments {
+			if assignment.Role.Name == roleName {
+				return &assignment, nil
 			}
 		}
 	}


### PR DESCRIPTION
Closes #205

[ENG-7561](https://stacklet.atlassian.net/browse/ENG-7561)

### what

Remove `RoleAssignment *RoleAssignment` from `GrantRoleAssignmentPayload` and drop the nil-gate that prevented `List()` from being called after a successful grant.

### why

`go-graphql-client` reflects `GrantRoleAssignmentPayload` to build the mutation query, requesting the full `roleAssignment{...}` fragment including union type variants. On production Stacklet instances the server returns `roleAssignment` in a format that `jsonutil.UnmarshalGraphQL` cannot reconcile, producing:

```
graphql_decode_error: slice doesn't exist in any of 1 places to unmarshal
```

This causes `Create()` to error even though the assignment was successfully created server-side, leaving the resource permanently broken since Terraform never writes state. Subsequent `terraform apply` runs fail at plan time with the same error.

The field was never used — `Create()` always resolved the assignment by calling `List()` regardless. By not requesting `roleAssignment`, the server cannot return an incompatible payload. The nil-gate on the field was also a secondary bug: if the field was null, the gate would prevent `List()` from running and return a false `NotFound` error.

### testing

Existing acceptance tests pass in replay mode. Cassette recordings for `TestAccRoleAssignmentResource` and `TestAccRoleAssignmentResource_AccountGroup` updated to reflect the shorter mutation query (keys, `request.query`, and grant response bodies). `TestAccRoleAssignmentResource_SSOGroup` had no `updateRoleAssignment` entries and needed no changes.

### docs

No documentation changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-7561]: https://stacklet.atlassian.net/browse/ENG-7561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ