### PR TITLE
fix: remove deprecated/underclared user datasource fields

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -43,17 +43,10 @@ output "user_email" {
 ### Read-Only
 
 - `active` (Boolean) Whether the user is active in the system.
-- `all_roles` (List of String) All roles (assigned, implicit, and inherited) for the user.
-- `assigned_roles` (List of String) Roles directly assigned to the user.
 - `display_name` (String) The display name of the user.
 - `email` (String) The email address of the user.
-- `groups` (List of String) Groups the user belongs to.
 - `id` (String) The GraphQL Node ID of the user.
-- `implicit_roles` (List of String) Roles implicitly granted to the user.
-- `inherited_roles` (List of String) Roles inherited by the user.
-- `key` (Number) The numeric key of the user.
-- `last_login` (String) The timestamp of the user's last login.
+- `key` (Number) The numeric key identifier of the user.
 - `name` (String) The name of the user.
 - `role_assignment_principal` (String) An opaque principal identifier for role assignments. Use this value when creating role assignments.
-- `roles` (List of String) Roles assigned to the user.
 - `sso_user` (Boolean) Whether the user is an SSO user.

--- a/internal/acceptance_tests/recordings/TestAccSSOGroupDataSource.json
+++ b/internal/acceptance_tests/recordings/TestAccSSOGroupDataSource.json
@@ -1,0 +1,91 @@
+{
+  "query ($filterElement:FilterElementInput!){ssoGroups(filterElement: $filterElement){edges{node{id,displayName,name,roleAssignmentPrincipal}}}}:{\"filterElement\":{\"single\":{\"name\":\"name\",\"value\":\"test-sso\"}}}": [
+    {
+      "request": {
+        "query": "query ($filterElement:FilterElementInput!){ssoGroups(filterElement: $filterElement){edges{node{id,displayName,name,roleAssignmentPrincipal}}}}",
+        "variables": {
+          "filterElement": {
+            "single": {
+              "name": "name",
+              "value": "test-sso"
+            }
+          }
+        }
+      },
+      "response": {
+        "data": {
+          "ssoGroups": {
+            "edges": [
+              {
+                "node": {
+                  "displayName": null,
+                  "id": "WyJzc28tZ3JvdXAiLCAiMiJd",
+                  "name": "test-sso",
+                  "roleAssignmentPrincipal": "sso-group:2"
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "query": "query ($filterElement:FilterElementInput!){ssoGroups(filterElement: $filterElement){edges{node{id,displayName,name,roleAssignmentPrincipal}}}}",
+        "variables": {
+          "filterElement": {
+            "single": {
+              "name": "name",
+              "value": "test-sso"
+            }
+          }
+        }
+      },
+      "response": {
+        "data": {
+          "ssoGroups": {
+            "edges": [
+              {
+                "node": {
+                  "displayName": null,
+                  "id": "WyJzc28tZ3JvdXAiLCAiMiJd",
+                  "name": "test-sso",
+                  "roleAssignmentPrincipal": "sso-group:2"
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "query": "query ($filterElement:FilterElementInput!){ssoGroups(filterElement: $filterElement){edges{node{id,displayName,name,roleAssignmentPrincipal}}}}",
+        "variables": {
+          "filterElement": {
+            "single": {
+              "name": "name",
+              "value": "test-sso"
+            }
+          }
+        }
+      },
+      "response": {
+        "data": {
+          "ssoGroups": {
+            "edges": [
+              {
+                "node": {
+                  "displayName": null,
+                  "id": "WyJzc28tZ3JvdXAiLCAiMiJd",
+                  "name": "test-sso",
+                  "roleAssignmentPrincipal": "sso-group:2"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/internal/acceptance_tests/recordings/TestAccUserDataSource.json
+++ b/internal/acceptance_tests/recordings/TestAccUserDataSource.json
@@ -1,0 +1,106 @@
+{
+  "query ($filterElement:FilterElementInput!){users(filterElement: $filterElement){edges{node{id,active,displayName,email,name,key,roleAssignmentPrincipal,ssoUser,username}}}}:{\"filterElement\":{\"single\":{\"name\":\"username\",\"value\":\"test_at_stacklet.io\"}}}": [
+    {
+      "request": {
+        "query": "query ($filterElement:FilterElementInput!){users(filterElement: $filterElement){edges{node{id,active,displayName,email,name,key,roleAssignmentPrincipal,ssoUser,username}}}}",
+        "variables": {
+          "filterElement": {
+            "single": {
+              "name": "username",
+              "value": "test_at_stacklet.io"
+            }
+          }
+        }
+      },
+      "response": {
+        "data": {
+          "users": {
+            "edges": [
+              {
+                "node": {
+                  "active": true,
+                  "displayName": null,
+                  "email": "test@stacklet.io",
+                  "id": "WyJ1c2VyIiwgIjIxIl0=",
+                  "key": 21,
+                  "name": "test-user",
+                  "roleAssignmentPrincipal": "user:21",
+                  "ssoUser": false,
+                  "username": "test_at_stacklet.io"
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "query": "query ($filterElement:FilterElementInput!){users(filterElement: $filterElement){edges{node{id,active,displayName,email,name,key,roleAssignmentPrincipal,ssoUser,username}}}}",
+        "variables": {
+          "filterElement": {
+            "single": {
+              "name": "username",
+              "value": "test_at_stacklet.io"
+            }
+          }
+        }
+      },
+      "response": {
+        "data": {
+          "users": {
+            "edges": [
+              {
+                "node": {
+                  "active": true,
+                  "displayName": null,
+                  "email": "test@stacklet.io",
+                  "id": "WyJ1c2VyIiwgIjIxIl0=",
+                  "key": 21,
+                  "name": "test-user",
+                  "roleAssignmentPrincipal": "user:21",
+                  "ssoUser": false,
+                  "username": "test_at_stacklet.io"
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "query": "query ($filterElement:FilterElementInput!){users(filterElement: $filterElement){edges{node{id,active,displayName,email,name,key,roleAssignmentPrincipal,ssoUser,username}}}}",
+        "variables": {
+          "filterElement": {
+            "single": {
+              "name": "username",
+              "value": "test_at_stacklet.io"
+            }
+          }
+        }
+      },
+      "response": {
+        "data": {
+          "users": {
+            "edges": [
+              {
+                "node": {
+                  "active": true,
+                  "displayName": null,
+                  "email": "test@stacklet.io",
+                  "id": "WyJ1c2VyIiwgIjIxIl0=",
+                  "key": 21,
+                  "name": "test-user",
+                  "roleAssignmentPrincipal": "user:21",
+                  "ssoUser": false,
+                  "username": "test_at_stacklet.io"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/internal/acceptance_tests/role_assignment_resource_test.go
+++ b/internal/acceptance_tests/role_assignment_resource_test.go
@@ -4,7 +4,6 @@ package acceptance_tests
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -12,12 +11,7 @@ import (
 )
 
 func TestAccRoleAssignmentResource(t *testing.T) {
-	testUsername := os.Getenv("TF_ACC_TEST_USERNAME")
-
-	if testUsername == "" {
-		t.Skip("TF_ACC_TEST_USERNAME environment variable must be set to run this test")
-	}
-
+	testUsername := getenvOrSkip(t, "TF_ACC_TEST_USERNAME")
 	userDataSourceConfig := fmt.Sprintf(`username = %q`, testUsername)
 
 	steps := []resource.TestStep{
@@ -94,12 +88,7 @@ func TestAccRoleAssignmentResource(t *testing.T) {
 }
 
 func TestAccRoleAssignmentResource_SSOGroup(t *testing.T) {
-	// Require TF_ACC_TEST_SSO_GROUP environment variable
-	testSSOGroup := os.Getenv("TF_ACC_TEST_SSO_GROUP")
-	if testSSOGroup == "" {
-		t.Skip("TF_ACC_TEST_SSO_GROUP environment variable must be set to run this test")
-	}
-
+	testSSOGroup := getenvOrSkip(t, "TF_ACC_TEST_SSO_GROUP")
 	steps := []resource.TestStep{
 		// Create role assignment for SSO group
 		{
@@ -126,20 +115,13 @@ func TestAccRoleAssignmentResource_SSOGroup(t *testing.T) {
 }
 
 func TestAccRoleAssignmentResource_AccountGroup(t *testing.T) {
-	testUsername := os.Getenv("TF_ACC_TEST_USERNAME")
-
-	if testUsername == "" {
-		t.Skip("TF_ACC_TEST_USERNAME environment variable must be set to run this test")
-	}
-
-	userDataSourceConfig := fmt.Sprintf(`username = %q`, testUsername)
-
+	testUsername := getenvOrSkip(t, "TF_ACC_TEST_USERNAME")
 	steps := []resource.TestStep{
 		// Create role assignment on account group target
 		{
 			Config: fmt.Sprintf(`
 				data "stacklet_user" "test" {
-					%s
+					username = %q
 				}
 
 				resource "stacklet_account_group" "test" {
@@ -154,7 +136,7 @@ func TestAccRoleAssignmentResource_AccountGroup(t *testing.T) {
 					principal = data.stacklet_user.test.role_assignment_principal
 					target    = stacklet_account_group.test.role_assignment_target
 				}
-			`, userDataSourceConfig),
+			`, testUsername),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("stacklet_role_assignment.test", "role_name", "viewer"),
 				resource.TestCheckResourceAttrSet("stacklet_role_assignment.test", "id"),

--- a/internal/acceptance_tests/sso_group_data_source_test.go
+++ b/internal/acceptance_tests/sso_group_data_source_test.go
@@ -4,19 +4,13 @@ package acceptance_tests
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccSSOGroupDataSource(t *testing.T) {
-	// Require TF_ACC_TEST_SSO_GROUP environment variable
-	testSSOGroup := os.Getenv("TF_ACC_TEST_SSO_GROUP")
-	if testSSOGroup == "" {
-		t.Skip("TF_ACC_TEST_SSO_GROUP environment variable must be set to run this test")
-	}
-
+	testSSOGroup := getenvOrSkip(t, "TF_ACC_TEST_SSO_GROUP")
 	steps := []resource.TestStep{
 		{
 			Config: fmt.Sprintf(`

--- a/internal/acceptance_tests/testing.go
+++ b/internal/acceptance_tests/testing.go
@@ -122,6 +122,14 @@ func getenv(name, fallback string) string {
 	return value
 }
 
+func getenvOrSkip(t *testing.T, name string) string {
+	value := os.Getenv(name)
+	if value == "" {
+		t.Skipf("%s environment variable must be set to run this test", name)
+	}
+	return value
+}
+
 func renderConfigs(t *testing.T, testSteps []resource.TestStep) {
 	data := getConfigData()
 	for i, step := range testSteps {

--- a/internal/acceptance_tests/user_data_source_test.go
+++ b/internal/acceptance_tests/user_data_source_test.go
@@ -4,43 +4,29 @@ package acceptance_tests
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccUserDataSource(t *testing.T) {
-	testUsername := os.Getenv("TF_ACC_TEST_USERNAME")
-
-	if testUsername == "" {
-		t.Skip("TF_ACC_TEST_USERNAME environment variable must be set to run this test")
-	}
-
-	config := fmt.Sprintf(`
-		data "stacklet_user" "test" {
-		  username = %q
-		}
-	`, testUsername)
-
+	testUsername := getenvOrSkip(t, "TF_ACC_TEST_USERNAME")
 	steps := []resource.TestStep{
 		{
-			Config: config,
+			Config: fmt.Sprintf(`
+ 				data "stacklet_user" "test" {
+					username = "%s"
+				}
+			`, testUsername),
 			Check: resource.ComposeAggregateTestCheckFunc(
-				// Check user attributes
 				resource.TestCheckResourceAttr("data.stacklet_user.test", "username", testUsername),
 				resource.TestCheckResourceAttrSet("data.stacklet_user.test", "id"),
+				resource.TestCheckResourceAttrSet("data.stacklet_user.test", "key"),
 				resource.TestCheckResourceAttrSet("data.stacklet_user.test", "name"),
+				resource.TestCheckResourceAttrSet("data.stacklet_user.test", "email"),
 				resource.TestCheckResourceAttrSet("data.stacklet_user.test", "role_assignment_principal"),
 				resource.TestCheckResourceAttrSet("data.stacklet_user.test", "active"),
 				resource.TestCheckResourceAttrSet("data.stacklet_user.test", "sso_user"),
-				// Check that role lists are present (may be empty)
-				resource.TestCheckResourceAttrSet("data.stacklet_user.test", "all_roles.#"),
-				resource.TestCheckResourceAttrSet("data.stacklet_user.test", "assigned_roles.#"),
-				resource.TestCheckResourceAttrSet("data.stacklet_user.test", "implicit_roles.#"),
-				resource.TestCheckResourceAttrSet("data.stacklet_user.test", "inherited_roles.#"),
-				resource.TestCheckResourceAttrSet("data.stacklet_user.test", "roles.#"),
-				resource.TestCheckResourceAttrSet("data.stacklet_user.test", "groups.#"),
 			),
 		},
 	}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -15,6 +15,7 @@ type User struct {
 	DisplayName             *string
 	Email                   *string
 	Name                    *string
+	Key                     int64
 	RoleAssignmentPrincipal string
 	SSOUser                 bool
 	Username                *string

--- a/internal/datasources/user.go
+++ b/internal/datasources/user.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/stacklet/terraform-provider-stacklet/internal/errors"
 	"github.com/stacklet/terraform-provider-stacklet/internal/models"
@@ -39,16 +38,6 @@ func (d *userDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, r
 				Description: "Whether the user is active in the system.",
 				Computed:    true,
 			},
-			"all_roles": schema.ListAttribute{
-				Description: "All roles (assigned, implicit, and inherited) for the user.",
-				Computed:    true,
-				ElementType: types.StringType,
-			},
-			"assigned_roles": schema.ListAttribute{
-				Description: "Roles directly assigned to the user.",
-				Computed:    true,
-				ElementType: types.StringType,
-			},
 			"display_name": schema.StringAttribute{
 				Description: "The display name of the user.",
 				Computed:    true,
@@ -57,27 +46,8 @@ func (d *userDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, r
 				Description: "The email address of the user.",
 				Computed:    true,
 			},
-			"groups": schema.ListAttribute{
-				Description: "Groups the user belongs to.",
-				Computed:    true,
-				ElementType: types.StringType,
-			},
-			"implicit_roles": schema.ListAttribute{
-				Description: "Roles implicitly granted to the user.",
-				Computed:    true,
-				ElementType: types.StringType,
-			},
-			"inherited_roles": schema.ListAttribute{
-				Description: "Roles inherited by the user.",
-				Computed:    true,
-				ElementType: types.StringType,
-			},
 			"key": schema.Int64Attribute{
-				Description: "The numeric key of the user.",
-				Computed:    true,
-			},
-			"last_login": schema.StringAttribute{
-				Description: "The timestamp of the user's last login.",
+				Description: "The numeric key identifier of the user.",
 				Computed:    true,
 			},
 			"name": schema.StringAttribute{
@@ -87,11 +57,6 @@ func (d *userDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, r
 			"role_assignment_principal": schema.StringAttribute{
 				Description: "An opaque principal identifier for role assignments. Use this value when creating role assignments.",
 				Computed:    true,
-			},
-			"roles": schema.ListAttribute{
-				Description: "Roles assigned to the user.",
-				Computed:    true,
-				ElementType: types.StringType,
 			},
 			"sso_user": schema.BoolAttribute{
 				Description: "Whether the user is an SSO user.",

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -18,6 +18,7 @@ type UserDataSource struct {
 	DisplayName             types.String `tfsdk:"display_name"`
 	Email                   types.String `tfsdk:"email"`
 	Name                    types.String `tfsdk:"name"`
+	Key                     types.Int64  `tfsdk:"key"`
 	RoleAssignmentPrincipal types.String `tfsdk:"role_assignment_principal"`
 	SSOUser                 types.Bool   `tfsdk:"sso_user"`
 	Username                types.String `tfsdk:"username"`
@@ -31,6 +32,7 @@ func (m *UserDataSource) Update(ctx context.Context, user *api.User) diag.Diagno
 	m.DisplayName = types.StringPointerValue(user.DisplayName)
 	m.Email = types.StringPointerValue(user.Email)
 	m.Name = types.StringPointerValue(user.Name)
+	m.Key = types.Int64Value(user.Key)
 	m.RoleAssignmentPrincipal = types.StringValue(user.RoleAssignmentPrincipal)
 	m.SSOUser = types.BoolValue(user.SSOUser)
 	m.Username = types.StringPointerValue(user.Username)


### PR DESCRIPTION
### what

remove some user (deprecated) datasource fields that were never used

### why

the datasource is currently not working as those fields are missing in the model

### testing

tested locally, added test recording

### docs

updated
