### PR TITLE
feat: add stacklet_gcp_integration_surface datasource [ENG-6977]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,6 +127,11 @@ jobs:
         with:
           postfix: _TOOL_VERSION
 
+      - name: Setup Just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        with:
+          just-version: ${{ env.JUST_TOOL_VERSION }}
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
@@ -138,7 +143,5 @@ jobs:
           go-version: ${{ env.GOLANG_TOOL_VERSION }}
 
       - name: Test
-        env:
-          TF_ACC: "1"
         run: |
-          go test ./internal/...
+          just test

--- a/internal/acceptance_tests/gcp_integration_surface_data_source_test.go
+++ b/internal/acceptance_tests/gcp_integration_surface_data_source_test.go
@@ -1,0 +1,29 @@
+// Copyright Stacklet, Inc. 2025, 2026
+
+package acceptance_tests
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccGCPIntegrationSurfaceDataSource(t *testing.T) {
+	steps := []resource.TestStep{
+		{
+			Config: `
+					data "stacklet_gcp_integration_surface" "test" {}
+				`,
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttrSet("data.stacklet_gcp_integration_surface.test", "trust_aws.account_id"),
+				resource.TestCheckResourceAttrSet("data.stacklet_gcp_integration_surface.test", "trust_aws.assetdb_role_name"),
+				resource.TestCheckResourceAttrSet("data.stacklet_gcp_integration_surface.test", "trust_aws.cost_query_role_name"),
+				resource.TestCheckResourceAttrSet("data.stacklet_gcp_integration_surface.test", "trust_aws.execution_role_name"),
+				resource.TestCheckResourceAttrSet("data.stacklet_gcp_integration_surface.test", "trust_aws.platform_role_name"),
+				resource.TestCheckResourceAttrSet("data.stacklet_gcp_integration_surface.test", "aws_relay.bus_arn"),
+				resource.TestCheckResourceAttrSet("data.stacklet_gcp_integration_surface.test", "aws_relay.role_arn"),
+			),
+		},
+	}
+	runRecordedAccTest(t, "TestAccGCPIntegrationSurfaceDataSource", steps)
+}

--- a/internal/acceptance_tests/recordings/TestAccGCPIntegrationSurfaceDataSource.json
+++ b/internal/acceptance_tests/recordings/TestAccGCPIntegrationSurfaceDataSource.json
@@ -1,0 +1,70 @@
+{
+  "{gcpIntegrationSurface{trustAws{accountId,assetdbRoleName,costQueryRoleName,executionRoleName,platformRoleName},awsRelay{busArn,roleArn}}}": [
+    {
+      "request": {
+        "query": "{gcpIntegrationSurface{trustAws{accountId,assetdbRoleName,costQueryRoleName,executionRoleName,platformRoleName},awsRelay{busArn,roleArn}}}"
+      },
+      "response": {
+        "data": {
+          "gcpIntegrationSurface": {
+            "awsRelay": {
+              "busArn": "arn:aws:events:eu-north-1:905418385756:event-bus/ack-gcp-relay",
+              "roleArn": "arn:aws:iam::905418385756:role/ack-gcp-enclave"
+            },
+            "trustAws": {
+              "accountId": "905418385756",
+              "assetdbRoleName": "ack-collector",
+              "costQueryRoleName": "ack-cur-read",
+              "executionRoleName": "ack-stacklet-execution",
+              "platformRoleName": "ack-stacklet-platform"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "query": "{gcpIntegrationSurface{trustAws{accountId,assetdbRoleName,costQueryRoleName,executionRoleName,platformRoleName},awsRelay{busArn,roleArn}}}"
+      },
+      "response": {
+        "data": {
+          "gcpIntegrationSurface": {
+            "awsRelay": {
+              "busArn": "arn:aws:events:eu-north-1:905418385756:event-bus/ack-gcp-relay",
+              "roleArn": "arn:aws:iam::905418385756:role/ack-gcp-enclave"
+            },
+            "trustAws": {
+              "accountId": "905418385756",
+              "assetdbRoleName": "ack-collector",
+              "costQueryRoleName": "ack-cur-read",
+              "executionRoleName": "ack-stacklet-execution",
+              "platformRoleName": "ack-stacklet-platform"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "query": "{gcpIntegrationSurface{trustAws{accountId,assetdbRoleName,costQueryRoleName,executionRoleName,platformRoleName},awsRelay{busArn,roleArn}}}"
+      },
+      "response": {
+        "data": {
+          "gcpIntegrationSurface": {
+            "awsRelay": {
+              "busArn": "arn:aws:events:eu-north-1:905418385756:event-bus/ack-gcp-relay",
+              "roleArn": "arn:aws:iam::905418385756:role/ack-gcp-enclave"
+            },
+            "trustAws": {
+              "accountId": "905418385756",
+              "assetdbRoleName": "ack-collector",
+              "costQueryRoleName": "ack-cur-read",
+              "executionRoleName": "ack-stacklet-execution",
+              "platformRoleName": "ack-stacklet-platform"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -30,6 +30,27 @@ type MSTeamsIntegrationSurface struct {
 	TrustRoleARN string `graphql:"trustRoleARN"`
 }
 
+// GCPIntegrationSurface is the data returned by reading GCP integration configuration details.
+type GCPIntegrationSurface struct {
+	TrustAws GCPIntegrationSurfaceTrustAws `graphql:"trustAws"`
+	AwsRelay GCPIntegrationSurfaceAwsRelay `graphql:"awsRelay"`
+}
+
+// GCPIntegrationSurfaceTrustAws holds AWS trust configuration for GCP integration.
+type GCPIntegrationSurfaceTrustAws struct {
+	AccountID         string `graphql:"accountId"`
+	AssetdbRoleName   string `graphql:"assetdbRoleName"`
+	CostQueryRoleName string `graphql:"costQueryRoleName"`
+	ExecutionRoleName string `graphql:"executionRoleName"`
+	PlatformRoleName  string `graphql:"platformRoleName"`
+}
+
+// GCPIntegrationSurfaceAwsRelay holds AWS relay configuration for GCP integration.
+type GCPIntegrationSurfaceAwsRelay struct {
+	BusArn  string `graphql:"busArn"`
+	RoleArn string `graphql:"roleArn"`
+}
+
 type systemAPI struct {
 	c *graphql.Client
 }
@@ -54,4 +75,15 @@ func (a systemAPI) MSTeamsIntegrationSurface(ctx context.Context) (*MSTeamsInteg
 		return nil, NewAPIError(err)
 	}
 	return &query.MSTeamsIntegrationSurface, nil
+}
+
+// GCPIntegrationSurface returns details for the GCP platform integration.
+func (a systemAPI) GCPIntegrationSurface(ctx context.Context) (*GCPIntegrationSurface, error) {
+	var query struct {
+		GCPIntegrationSurface GCPIntegrationSurface `graphql:"gcpIntegrationSurface"`
+	}
+	if err := a.c.Query(ctx, &query, nil); err != nil {
+		return nil, NewAPIError(err)
+	}
+	return &query.GCPIntegrationSurface, nil
 }

--- a/internal/datasources/datasources.go
+++ b/internal/datasources/datasources.go
@@ -7,8 +7,8 @@ import (
 )
 
 // DataSources returns all available datasources..
-func DataSources() []func() datasource.DataSource {
-	return []func() datasource.DataSource{
+func DataSources(includeUnreleased bool) []func() datasource.DataSource {
+	dataSources := []func() datasource.DataSource{
 		newAccountDataSource,
 		newAccountGroupDataSource,
 		newBindingDataSource,
@@ -27,9 +27,16 @@ func DataSources() []func() datasource.DataSource {
 		newPolicyDataSource,
 		newReportgroupDataSource,
 		newRepositoryDataSource,
-		newRoleDataSource,
 		newRoleAssignmentsDataSource,
+		newRoleDataSource,
 		newSSOGroupDataSource,
 		newUserDataSource,
 	}
+	unreleasedDataSources := []func() datasource.DataSource{
+		newGCPIntegrationSurfaceDataSource,
+	}
+	if includeUnreleased {
+		dataSources = append(dataSources, unreleasedDataSources...)
+	}
+	return dataSources
 }

--- a/internal/datasources/gcp_integration_surface.go
+++ b/internal/datasources/gcp_integration_surface.go
@@ -1,0 +1,94 @@
+// Copyright Stacklet, Inc. 2025, 2026
+
+package datasources
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+
+	"github.com/stacklet/terraform-provider-stacklet/internal/errors"
+	"github.com/stacklet/terraform-provider-stacklet/internal/models"
+)
+
+var (
+	_ datasource.DataSource = &gcpIntegrationSurfaceDataSource{}
+)
+
+func newGCPIntegrationSurfaceDataSource() datasource.DataSource {
+	return &gcpIntegrationSurfaceDataSource{}
+}
+
+type gcpIntegrationSurfaceDataSource struct {
+	apiDataSource
+}
+
+func (d *gcpIntegrationSurfaceDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_gcp_integration_surface"
+}
+
+func (d *gcpIntegrationSurfaceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Retrieve GCP integration configuration details.",
+		Attributes: map[string]schema.Attribute{
+			"trust_aws": schema.SingleNestedAttribute{
+				Description: "AWS trust configuration for GCP integration.",
+				Computed:    true,
+				Attributes: map[string]schema.Attribute{
+					"account_id": schema.StringAttribute{
+						Description: "The Stacklet deployment AWS account ID that GCP should integrate with.",
+						Computed:    true,
+					},
+					"assetdb_role_name": schema.StringAttribute{
+						Description: "The name of the IAM role used for AssetDB access.",
+						Computed:    true,
+					},
+					"cost_query_role_name": schema.StringAttribute{
+						Description: "The name of the IAM role used for cost queries access.",
+						Computed:    true,
+					},
+					"execution_role_name": schema.StringAttribute{
+						Description: "The name of the IAM role used for execution.",
+						Computed:    true,
+					},
+					"platform_role_name": schema.StringAttribute{
+						Description: "The name of the IAM role used for platform access.",
+						Computed:    true,
+					},
+				},
+			},
+			"aws_relay": schema.SingleNestedAttribute{
+				Description: "AWS relay configuration for GCP integration.",
+				Computed:    true,
+				Attributes: map[string]schema.Attribute{
+					"bus_arn": schema.StringAttribute{
+						Description: "The ARN of the AWS EventBridge bus to relay events to.",
+						Computed:    true,
+					},
+					"role_arn": schema.StringAttribute{
+						Description: "The ARN of the AWS IAM role used for the relay.",
+						Computed:    true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *gcpIntegrationSurfaceDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data models.GCPIntegrationSurfaceDataSource
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	surface, err := d.api.System.GCPIntegrationSurface(ctx)
+	if err != nil {
+		errors.AddDiagError(&resp.Diagnostics, err)
+		return
+	}
+
+	resp.Diagnostics.Append(data.Update(ctx, surface)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/models/gcp_integration_surface.go
+++ b/internal/models/gcp_integration_surface.go
@@ -1,0 +1,51 @@
+// Copyright Stacklet, Inc. 2025, 2026
+
+package models
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/stacklet/terraform-provider-stacklet/internal/api"
+)
+
+// GCPIntegrationSurfaceTrustAWS holds details for the AWS trust configuration for GCP integration.
+type GCPIntegrationSurfaceTrustAWS struct {
+	AccountID         types.String `tfsdk:"account_id"`
+	AssetDBRoleName   types.String `tfsdk:"assetdb_role_name"`
+	CostQueryRoleName types.String `tfsdk:"cost_query_role_name"`
+	ExecutionRoleName types.String `tfsdk:"execution_role_name"`
+	PlatformRoleName  types.String `tfsdk:"platform_role_name"`
+}
+
+// GCPIntegrationSurfaceAWSRelay holds details for the AWS relay configuration for GCP integration.
+type GCPIntegrationSurfaceAWSRelay struct {
+	BusARN  types.String `tfsdk:"bus_arn"`
+	RoleARN types.String `tfsdk:"role_arn"`
+}
+
+// GCPIntegrationSurfaceDataSource is the model for the GCP integration surface data source.
+type GCPIntegrationSurfaceDataSource struct {
+	TrustAWS *GCPIntegrationSurfaceTrustAWS `tfsdk:"trust_aws"`
+	AWSRelay *GCPIntegrationSurfaceAWSRelay `tfsdk:"aws_relay"`
+}
+
+func (m *GCPIntegrationSurfaceDataSource) Update(_ context.Context, surface *api.GCPIntegrationSurface) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	m.TrustAWS = &GCPIntegrationSurfaceTrustAWS{
+		AccountID:         types.StringValue(surface.TrustAws.AccountID),
+		AssetDBRoleName:   types.StringValue(surface.TrustAws.AssetdbRoleName),
+		CostQueryRoleName: types.StringValue(surface.TrustAws.CostQueryRoleName),
+		ExecutionRoleName: types.StringValue(surface.TrustAws.ExecutionRoleName),
+		PlatformRoleName:  types.StringValue(surface.TrustAws.PlatformRoleName),
+	}
+	m.AWSRelay = &GCPIntegrationSurfaceAWSRelay{
+		BusARN:  types.StringValue(surface.AwsRelay.BusArn),
+		RoleARN: types.StringValue(surface.AwsRelay.RoleArn),
+	}
+
+	return diags
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -34,7 +34,8 @@ type stackletProviderModel struct {
 func New(version string) func() provider.Provider {
 	return func() provider.Provider {
 		return &stackletProvider{
-			version: version,
+			version:           version,
+			includeUnreleased: os.Getenv("STACKLET_UNRELEASED_FEATURES") != "",
 		}
 	}
 }
@@ -44,6 +45,9 @@ type stackletProvider struct {
 	// provider is built and run locally, and "test" when running acceptance
 	// testing.
 	version string
+
+	// whether to include unreleased resources/datasources
+	includeUnreleased bool
 }
 
 // Metadata returns the provider type name.
@@ -146,12 +150,12 @@ func (p *stackletProvider) Configure(ctx context.Context, req provider.Configure
 
 // DataSources defines the data sources implemented in the provider.
 func (p *stackletProvider) DataSources(_ context.Context) []func() datasource.DataSource {
-	return datasources.DataSources()
+	return datasources.DataSources(p.includeUnreleased)
 }
 
 // Resources defines the resources implemented in the provider.
 func (p *stackletProvider) Resources(_ context.Context) []func() resource.Resource {
-	return resources.Resources()
+	return resources.Resources(p.includeUnreleased)
 }
 
 type credentials struct {

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -7,8 +7,8 @@ import (
 )
 
 // Resources returns all available resources.
-func Resources() []func() resource.Resource {
-	return []func() resource.Resource{
+func Resources(includeUnreleased bool) []func() resource.Resource {
+	resources := []func() resource.Resource{
 		newAccountDiscoveryAWSResource,
 		newAccountDiscoveryAzureResource,
 		newAccountDiscoveryGCPResource,
@@ -33,4 +33,9 @@ func Resources() []func() resource.Resource {
 		newSSOGroupResource,
 		newUserResource,
 	}
+	unreleasedResources := []func() resource.Resource{}
+	if includeUnreleased {
+		resources = append(resources, unreleasedResources...)
+	}
+	return resources
 }

--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ lint-copyright:
 
 # Run tests using recorded API requests/responses.
 test *args:
-    TF_ACC=1 go test {{ package }} {{ args }}
+    TF_ACC=1 STACKLET_UNRELEASED_FEATURES=1 go test {{ package }} {{ args }}
 
 # Run tests against a live deployment. Requires real STACKLET_ENDPOINT and STACKLET_API_KEY or logged in stacklet-admin.
 test-live *args:


### PR DESCRIPTION
[ENG-6977](https://stacklet.atlassian.net/browse/ENG-6977)

### what

add a datasource for the GCP integration surface

### why

allow fetching configuration for integrating GCP

### testing

tested locally, added test

### docs

updated here


[ENG-6977]: https://stacklet.atlassian.net/browse/ENG-6977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ