### PR TITLE
feat: support removal for account discoveries [ENG-6976]

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 golang        1.25
 golangci-lint v2.8.0
-just          1.40.0
+just          1.50.0

--- a/docs/resources/account_discovery_aws.md
+++ b/docs/resources/account_discovery_aws.md
@@ -17,8 +17,8 @@ resource "stacklet_account_discovery_aws" "example" {
   name           = "aws"
   description    = "Discovery of AWS account"
   org_read_role  = "arn:aws:iam::123456789012:role/StackletOrgReadRole"
-  member_role    = "arn:aws:iam::{Id}:role/StackletAssetDBRole"
-  custodian_role = "arn:aws:iam::{id}:role/StackletCustodianRole-{tag}"
+  member_role    = "arn:aws:iam::123456789012:role/StackletAssetDBRole"
+  custodian_role = "arn:aws:iam::123456789012:role/StackletCustodianRole"
 }
 ```
 

--- a/examples/resources/stacklet_account_discovery_aws/resource.tf
+++ b/examples/resources/stacklet_account_discovery_aws/resource.tf
@@ -2,6 +2,6 @@ resource "stacklet_account_discovery_aws" "example" {
   name           = "aws"
   description    = "Discovery of AWS account"
   org_read_role  = "arn:aws:iam::123456789012:role/StackletOrgReadRole"
-  member_role    = "arn:aws:iam::{Id}:role/StackletAssetDBRole"
-  custodian_role = "arn:aws:iam::{id}:role/StackletCustodianRole-{tag}"
+  member_role    = "arn:aws:iam::123456789012:role/StackletAssetDBRole"
+  custodian_role = "arn:aws:iam::123456789012:role/StackletCustodianRole"
 }

--- a/internal/api/account_discovery.go
+++ b/internal/api/account_discovery.go
@@ -87,6 +87,14 @@ func (i AccountDiscoveryGCPInput) GetGraphQLType() string {
 	return "UpsertGCPAccountDiscoveryInput"
 }
 
+type accountDiscoveryRemoveInput struct {
+	ID graphql.ID `json:"id"`
+}
+
+func (i accountDiscoveryRemoveInput) GetGraphQLType() string {
+	return "RemoveAccountDiscoveryInput"
+}
+
 type updateAccountDiscoveryScheduleInput struct {
 	Schedules []accountDiscoveryScheduleInput `json:"schedules"`
 }
@@ -161,6 +169,20 @@ func (a accountDiscoveryAPI) UpsertGCP(ctx context.Context, input AccountDiscove
 		return nil, NewAPIError(err)
 	}
 	return &mutation.Payload.AccountDiscovery, nil
+}
+
+// Remove deletes an account discovery by its GraphQL node ID.
+func (a accountDiscoveryAPI) Remove(ctx context.Context, id string) error {
+	var mutation struct {
+		Payload struct {
+			Problems []Problem
+		} `graphql:"removeAccountDiscovery(input: $input)"`
+	}
+	variables := map[string]any{"input": accountDiscoveryRemoveInput{ID: graphql.ID(id)}}
+	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
+		return NewAPIError(err)
+	}
+	return fromProblems(ctx, mutation.Payload.Problems)
 }
 
 // UpdateSuspended updates the susended flag for an account discovery.

--- a/internal/resources/account_discovery_aws.go
+++ b/internal/resources/account_discovery_aws.go
@@ -171,7 +171,15 @@ func (r *accountDiscoveryAWSResource) Update(ctx context.Context, req resource.U
 }
 
 func (r *accountDiscoveryAWSResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	resp.Diagnostics.AddError("Delete error", "Resource can't be deleted. Set `suspended = true` instead.")
+	var state models.AccountDiscoveryAWSResource
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.api.AccountDiscovery.Remove(ctx, state.ID.ValueString()); err != nil {
+		errors.AddDiagError(&resp.Diagnostics, err)
+	}
 }
 
 func (r *accountDiscoveryAWSResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/resources/account_discovery_azure.go
+++ b/internal/resources/account_discovery_azure.go
@@ -174,7 +174,15 @@ func (r *accountDiscoveryAzureResource) Update(ctx context.Context, req resource
 }
 
 func (r *accountDiscoveryAzureResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	resp.Diagnostics.AddError("Delete error", "Resource can't be deleted. Set `suspended = true` instead.")
+	var state models.AccountDiscoveryAzureResource
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.api.AccountDiscovery.Remove(ctx, state.ID.ValueString()); err != nil {
+		errors.AddDiagError(&resp.Diagnostics, err)
+	}
 }
 
 func (r *accountDiscoveryAzureResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/resources/account_discovery_gcp.go
+++ b/internal/resources/account_discovery_gcp.go
@@ -200,7 +200,15 @@ func (r *accountDiscoveryGCPResource) Update(ctx context.Context, req resource.U
 }
 
 func (r *accountDiscoveryGCPResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	resp.Diagnostics.AddError("Delete error", "Resource can't be deleted. Set `suspended = true` instead.")
+	var state models.AccountDiscoveryGCPResource
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.api.AccountDiscovery.Remove(ctx, state.ID.ValueString()); err != nil {
+		errors.AddDiagError(&resp.Diagnostics, err)
+	}
 }
 
 func (r *accountDiscoveryGCPResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {


### PR DESCRIPTION
[ENG-6976](https://stacklet.atlassian.net/browse/ENG-6976)

### what

support removal of account discoveries in addition to disabling them

### why

allow removing discoveries, not just disabling

### testing

testing in sandbox

### docs

n/a


[ENG-6976]: https://stacklet.atlassian.net/browse/ENG-6976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ