### PR TITLE
chore: add helper functions to preserve original model fields

### DIFF
--- a/internal/models/account.go
+++ b/internal/models/account.go
@@ -59,11 +59,7 @@ func (m *AccountResource) Update(account *api.Account) diag.Diagnostics {
 
 	diags := m.AccountDataSource.Update(account)
 
-	// the API returns an empty dictionary for both null or empty strings. In
-	// that case don't modify the expected value.
-	if m.Variables.ValueString() == "{}" {
-		m.Variables = originalVariables
-	}
+	m.Variables = typehelpers.PreserveIfEmptyJSON(m.Variables, originalVariables)
 
 	return diags
 }

--- a/internal/models/binding.go
+++ b/internal/models/binding.go
@@ -99,17 +99,8 @@ func (m *BindingResource) Update(ctx context.Context, binding *api.Binding) diag
 
 	diags := m.BindingDataSource.Update(ctx, binding)
 
-	// the API returns an empty dictionary for both null or empty strings. In
-	// that case don't modify the expected value.
-	if m.Variables.ValueString() == "{}" {
-		m.Variables = originalVariables
-	}
-
-	// The API omits executionConfig.dryRun when the value is false (treats null ≡ false).
-	// Preserve the configured value to prevent a perpetual null→false diff.
-	if m.DryRun.IsNull() && !originalDryRun.IsNull() {
-		m.DryRun = originalDryRun
-	}
+	m.Variables = typehelpers.PreserveIfEmptyJSON(m.Variables, originalVariables)
+	m.DryRun = typehelpers.PreserveIfNull(m.DryRun, originalDryRun)
 
 	// if default resource limits are set in the config but empty, apply default
 	if binding.DefaultResourceLimits() == nil && !originalResourceLimits.IsNull() {

--- a/internal/typehelpers/preserve.go
+++ b/internal/typehelpers/preserve.go
@@ -1,0 +1,23 @@
+// Copyright Stacklet, Inc. 2025, 2026
+
+package typehelpers
+
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
+// PreserveIfNull returns original when current is null but original is not.
+// Use when the API omits a field for its zero value, which would cause a perpetual plan diff.
+func PreserveIfNull[T interface{ IsNull() bool }](current, original T) T {
+	if current.IsNull() && !original.IsNull() {
+		return original
+	}
+	return current
+}
+
+// PreserveIfEmptyJSON returns original when current serialises as "{}".
+// Use when the API returns an empty dictionary for both null and empty values.
+func PreserveIfEmptyJSON(current, original types.String) types.String {
+	if current.ValueString() == "{}" {
+		return original
+	}
+	return current
+}


### PR DESCRIPTION
### what

add heleprs to preserve the previous value for model fields that are null or
empty JSON, since the API returns those instead of null

### why

consolidate similar logic used in a few places

### testing

tests pass

### docs

n/a
