### PR TITLE
feat: add datasource for GCP integration [ENG-6977]

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -15,6 +15,7 @@ type API struct {
 	AccountGroupMapping     accountGroupMappingAPI
 	Binding                 bindingAPI
 	ConfigurationProfile    configurationProfileAPI
+	GCPIntegration          gcpIntegrationAPI
 	Policy                  policyAPI
 	PolicyCollection        policyCollectionAPI
 	PolicyCollectionMapping policyCollectionMappingAPI
@@ -37,6 +38,7 @@ func New(c *graphql.Client) *API {
 		AccountGroupMapping:     accountGroupMappingAPI{c},
 		Binding:                 bindingAPI{c},
 		ConfigurationProfile:    configurationProfileAPI{c},
+		GCPIntegration:          gcpIntegrationAPI{c},
 		Policy:                  policyAPI{c},
 		PolicyCollection:        policyCollectionAPI{c},
 		PolicyCollectionMapping: policyCollectionMappingAPI{c},

--- a/internal/api/gcp_integration.go
+++ b/internal/api/gcp_integration.go
@@ -1,0 +1,156 @@
+// Copyright Stacklet, Inc. 2025, 2026
+
+package api
+
+import (
+	"context"
+
+	"github.com/hasura/go-graphql-client"
+)
+
+// GCPIntegration is the data for a GCP integration.
+type GCPIntegration struct {
+	ID             graphql.ID
+	Key            string
+	CustomerConfig GCPIntegrationCustomerConfig
+	AccessConfig   *GCPIntegrationAccessConfig
+}
+
+// GCPIntegrationCustomerConfig defines the customer-provided configuration for
+// the GCP integration.
+type GCPIntegrationCustomerConfig struct {
+	Infrastructure   *GCPIntegrationCustomerInfrastructure
+	Organizations    []GCPIntegrationCustomerOrganization
+	CostSources      []GCPIntegrationCustomerCostSource
+	SecurityContexts []GCPIntegrationCustomerSecurityContext
+	TerraformModule  *TerraformModule
+}
+
+// GCPIntegrationCustomerInfrastructure defines the project configuration for
+// the GCP integration deployment.
+type GCPIntegrationCustomerInfrastructure struct {
+	ProjectID        string `graphql:"projectId"`
+	ResourceLocation string
+	ResourcePrefix   string
+	CreateProject    *GCPIntegrationCustomerCreateProject
+}
+
+// GCPIntegrationCustomerCreateProject holds configuration for integration
+// project creation.
+type GCPIntegrationCustomerCreateProject struct {
+	BillingAccountID string  `graphql:"billingAccountId"`
+	OrgID            *string `graphql:"orgId"`
+	FolderID         *string `graphql:"folderId"`
+	Labels           []Tag
+}
+
+// GCPIntegrationCustomerOrganization identifies a GCP organization Stacklet will manage.
+type GCPIntegrationCustomerOrganization struct {
+	OrgID      string   `graphql:"orgId"`
+	FolderIDs  []string `graphql:"folderIds"`
+	ProjectIDs []string `graphql:"projectIds"`
+}
+
+// GCPIntegrationCustomerCostSource identifies a billing export table for cost data.
+type GCPIntegrationCustomerCostSource struct {
+	BillingTable string
+}
+
+// GCPIntegrationCustomerSecurityContext defines additional security context to
+// define in the integration.
+type GCPIntegrationCustomerSecurityContext struct {
+	Name       string
+	ExtraRoles []string
+}
+
+// GCPIntegrationAccessConfig holds the access details from the GCP
+// integration.
+type GCPIntegrationAccessConfig struct {
+	Infrastructure   GCPIntegrationAccessInfrastructure
+	Organizations    []GCPIntegrationAccessOrganization
+	CostSources      []GCPIntegrationAccessCostSource
+	SecurityContexts []GCPIntegrationAccessSecurityContext
+	RoundtripDigest  string
+}
+
+// GCPIntegrationAccessInfrastructure identifies the GCP infrastructure project.
+type GCPIntegrationAccessInfrastructure struct {
+	ProjectID     string `graphql:"projectId"`
+	Relay         GCPIntegrationAccessRelay
+	WIF           GCPIntegrationAccessWIF `graphql:"wif"`
+	BaselineRoles []string
+}
+
+// GCPIntegrationAccessRelay holds the relay identity credential.
+type GCPIntegrationAccessRelay struct {
+	OAuthID string `graphql:"oauthId"`
+}
+
+// GCPIntegrationAccessWIF holds the Workload Identity Federation configuration.
+type GCPIntegrationAccessWIF struct {
+	Audience   string
+	Principals GCPIntegrationAccessWIFPrincipals
+}
+
+// GCPIntegrationAccessWIFPrincipals identifies WIF principals by their intended role.
+type GCPIntegrationAccessWIFPrincipals struct {
+	ReadOnly  string
+	CostQuery string
+}
+
+// GCPIntegrationAccessOrganization identifies an accessible GCP organization.
+type GCPIntegrationAccessOrganization struct {
+	ID       string
+	Name     string
+	Folders  []GCPIntegrationAccessOrganizationFolder
+	Projects []GCPIntegrationAccessOrganizationProject
+}
+
+// GCPIntegrationAccessOrganizationFolder provides details about a connected organization folder.
+type GCPIntegrationAccessOrganizationFolder struct {
+	ID   string
+	Name string
+}
+
+// GCPIntegrationAccessOrganizationProject provides details about a connected organization project.
+type GCPIntegrationAccessOrganizationProject struct {
+	ID     string
+	Number string
+}
+
+// GCPIntegrationAccessCostSource identifies a billing export table and its location.
+type GCPIntegrationAccessCostSource struct {
+	BillingTable string
+	Location     string
+}
+
+// GCPIntegrationAccessSecurityContext defines a named set of roles granted to a principal.
+type GCPIntegrationAccessSecurityContext struct {
+	Name       string
+	ExtraRoles []string
+	Principal  string
+}
+
+type gcpIntegrationAPI struct {
+	c *graphql.Client
+}
+
+// Read returns data for a GCP integration by key.
+func (a gcpIntegrationAPI) Read(ctx context.Context, key string) (*GCPIntegration, error) {
+	var query struct {
+		Payload struct {
+			GCPIntegration *GCPIntegration `graphql:"gcpIntegration"`
+			Problems       []Problem
+		} `graphql:"gcpIntegration(key: $key)"`
+	}
+	if err := a.c.Query(ctx, &query, map[string]any{"key": graphql.String(key)}); err != nil {
+		return nil, NewAPIError(err)
+	}
+	if err := fromProblems(ctx, query.Payload.Problems); err != nil {
+		return nil, err
+	}
+	if query.Payload.GCPIntegration == nil {
+		return nil, NotFound{"GCP integration not found"}
+	}
+	return query.Payload.GCPIntegration, nil
+}

--- a/internal/datasources/datasources.go
+++ b/internal/datasources/datasources.go
@@ -33,6 +33,7 @@ func DataSources(includeUnreleased bool) []func() datasource.DataSource {
 		newUserDataSource,
 	}
 	unreleasedDataSources := []func() datasource.DataSource{
+		newGCPIntegrationDataSource,
 		newGCPIntegrationSurfaceDataSource,
 	}
 	if includeUnreleased {

--- a/internal/datasources/gcp_integration.go
+++ b/internal/datasources/gcp_integration.go
@@ -1,0 +1,334 @@
+// Copyright Stacklet, Inc. 2025, 2026
+
+package datasources
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/stacklet/terraform-provider-stacklet/internal/errors"
+	"github.com/stacklet/terraform-provider-stacklet/internal/models"
+)
+
+var (
+	_ datasource.DataSource = &gcpIntegrationDataSource{}
+)
+
+func newGCPIntegrationDataSource() datasource.DataSource {
+	return &gcpIntegrationDataSource{}
+}
+
+type gcpIntegrationDataSource struct {
+	apiDataSource
+}
+
+func (d *gcpIntegrationDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_gcp_integration"
+}
+
+func (d *gcpIntegrationDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	terraformModuleAttrs := map[string]schema.Attribute{
+		"repository_url": schema.StringAttribute{
+			Description: "The Terraform module repository URL.",
+			Computed:    true,
+		},
+		"source": schema.StringAttribute{
+			Description: "The Terraform module source.",
+			Computed:    true,
+		},
+		"version": schema.StringAttribute{
+			Description: "The Terraform module version.",
+			Computed:    true,
+		},
+		"variables_json": schema.StringAttribute{
+			Description: "The Terraform module variables as JSON.",
+			Computed:    true,
+		},
+	}
+
+	resp.Schema = schema.Schema{
+		Description: "Retrieve information about a GCP integration.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The GraphQL Node ID of the GCP integration.",
+				Computed:    true,
+			},
+			"key": schema.StringAttribute{
+				Description: "The key identifying the GCP integration.",
+				Required:    true,
+			},
+			"customer_config": schema.SingleNestedAttribute{
+				Description: "Customer-provided configuration defining the desired scope and surfaces Terraform to deploy it.",
+				Computed:    true,
+				Attributes: map[string]schema.Attribute{
+					"infrastructure": schema.SingleNestedAttribute{
+						Description: "The GCP project where Stacklet resources will be deployed.",
+						Computed:    true,
+						Attributes: map[string]schema.Attribute{
+							"project_id": schema.StringAttribute{
+								Description: "The GCP project ID for Stacklet infrastructure.",
+								Computed:    true,
+							},
+							"resource_location": schema.StringAttribute{
+								Description: "The GCP location for Stacklet resources.",
+								Computed:    true,
+							},
+							"resource_prefix": schema.StringAttribute{
+								Description: "The prefix prepended to all Stacklet-managed resource names.",
+								Computed:    true,
+							},
+							"create_project": schema.SingleNestedAttribute{
+								Description: "Configuration for creating the Stacklet infrastructure project, if applicable.",
+								Computed:    true,
+								Attributes: map[string]schema.Attribute{
+									"billing_account_id": schema.StringAttribute{
+										Description: "The billing account to associate with the created project.",
+										Computed:    true,
+									},
+									"org_id": schema.StringAttribute{
+										Description: "The organization in which to create the project.",
+										Computed:    true,
+									},
+									"folder_id": schema.StringAttribute{
+										Description: "The folder in which to create the project.",
+										Computed:    true,
+									},
+									"labels": schema.ListNestedAttribute{
+										Description: "Labels applied to the created project.",
+										Computed:    true,
+										NestedObject: schema.NestedAttributeObject{
+											Attributes: map[string]schema.Attribute{
+												"key": schema.StringAttribute{
+													Computed: true,
+												},
+												"value": schema.StringAttribute{
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"organizations": schema.ListNestedAttribute{
+						Description: "GCP organizations, folders, and projects Stacklet will manage.",
+						Computed:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"org_id": schema.StringAttribute{
+									Description: "The GCP organization ID.",
+									Computed:    true,
+								},
+								"folder_ids": schema.ListAttribute{
+									Description: "Folders to manage within the organization.",
+									Computed:    true,
+									ElementType: types.StringType,
+								},
+								"project_ids": schema.ListAttribute{
+									Description: "Individual projects to manage within the organization.",
+									Computed:    true,
+									ElementType: types.StringType,
+								},
+							},
+						},
+					},
+					"cost_sources": schema.ListNestedAttribute{
+						Description: "Billing export tables to use for cost data.",
+						Computed:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"billing_table": schema.StringAttribute{
+									Description: "The BigQuery table containing billing export data.",
+									Computed:    true,
+								},
+							},
+						},
+					},
+					"security_contexts": schema.ListNestedAttribute{
+						Description: "Named sets of extra roles to grant beyond the integration defaults.",
+						Computed:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"name": schema.StringAttribute{
+									Description: "The security context name.",
+									Computed:    true,
+								},
+								"extra_roles": schema.ListAttribute{
+									Description: "Additional GCP roles to grant for this context.",
+									Computed:    true,
+									ElementType: types.StringType,
+								},
+							},
+						},
+					},
+					"terraform_module": schema.SingleNestedAttribute{
+						Description: "Terraform module to deploy this integration, computed by Stacklet.",
+						Computed:    true,
+						Attributes:  terraformModuleAttrs,
+					},
+				},
+			},
+			"access_config": schema.SingleNestedAttribute{
+				Description: "Live connection details populated after Terraform has been applied; null until then.",
+				Computed:    true,
+				Attributes: map[string]schema.Attribute{
+					"infrastructure": schema.SingleNestedAttribute{
+						Description: "The GCP infrastructure project and its relay and WIF configuration.",
+						Computed:    true,
+						Attributes: map[string]schema.Attribute{
+							"project_id": schema.StringAttribute{
+								Description: "The GCP project hosting Stacklet infrastructure.",
+								Computed:    true,
+							},
+							"relay": schema.SingleNestedAttribute{
+								Description: "Event relay identity credential.",
+								Computed:    true,
+								Attributes: map[string]schema.Attribute{
+									"oauth_id": schema.StringAttribute{
+										Description: "The numeric unique_id of the events-relay Google Service Account.",
+										Computed:    true,
+									},
+								},
+							},
+							"wif": schema.SingleNestedAttribute{
+								Description: "Workload Identity Federation configuration.",
+								Computed:    true,
+								Attributes: map[string]schema.Attribute{
+									"audience": schema.StringAttribute{
+										Description: "The full resource name URI of the GCP WIF pool provider.",
+										Computed:    true,
+									},
+									"principals": schema.SingleNestedAttribute{
+										Description: "WIF service account principals by role.",
+										Computed:    true,
+										Attributes: map[string]schema.Attribute{
+											"read_only": schema.StringAttribute{
+												Description: "Service account email for read-only resource sync.",
+												Computed:    true,
+											},
+											"cost_query": schema.StringAttribute{
+												Description: "Service account email for cost queries.",
+												Computed:    true,
+											},
+										},
+									},
+								},
+							},
+							"baseline_roles": schema.ListAttribute{
+								Description: "Roles applied to all security contexts.",
+								Computed:    true,
+								ElementType: types.StringType,
+							},
+						},
+					},
+					"organizations": schema.ListNestedAttribute{
+						Description: "Accessible GCP organizations.",
+						Computed:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"id": schema.StringAttribute{
+									Description: "The GCP organization ID.",
+									Computed:    true,
+								},
+								"name": schema.StringAttribute{
+									Description: "The GCP organization name.",
+									Computed:    true,
+								},
+								"folders": schema.ListNestedAttribute{
+									Description: "Accessible folders within the organization.",
+									Computed:    true,
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											"id": schema.StringAttribute{
+												Computed: true,
+											},
+											"name": schema.StringAttribute{
+												Computed: true,
+											},
+										},
+									},
+								},
+								"projects": schema.ListNestedAttribute{
+									Description: "Accessible projects within the organization.",
+									Computed:    true,
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											"id": schema.StringAttribute{
+												Computed: true,
+											},
+											"number": schema.StringAttribute{
+												Computed: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"cost_sources": schema.ListNestedAttribute{
+						Description: "Billing export tables and their locations.",
+						Computed:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"billing_table": schema.StringAttribute{
+									Description: "The BigQuery table containing billing export data.",
+									Computed:    true,
+								},
+								"location": schema.StringAttribute{
+									Description: "The BigQuery dataset location.",
+									Computed:    true,
+								},
+							},
+						},
+					},
+					"security_contexts": schema.ListNestedAttribute{
+						Description: "Named sets of roles granted to principals.",
+						Computed:    true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"name": schema.StringAttribute{
+									Description: "The security context name.",
+									Computed:    true,
+								},
+								"extra_roles": schema.ListAttribute{
+									Description: "GCP roles granted in addition to the baseline ones.",
+									Computed:    true,
+									ElementType: types.StringType,
+								},
+								"principal": schema.StringAttribute{
+									Description: "The GCP identity granted these roles.",
+									Computed:    true,
+								},
+							},
+						},
+					},
+					"roundtrip_digest": schema.StringAttribute{
+						Description: "Digest of the customer config at deployment time.",
+						Computed:    true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *gcpIntegrationDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data models.GCPIntegrationDataSource
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	integration, err := d.api.GCPIntegration.Read(ctx, data.Key.ValueString())
+	if err != nil {
+		errors.AddDiagError(&resp.Diagnostics, err)
+		return
+	}
+
+	resp.Diagnostics.Append(data.Update(integration)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/models/gcp_integration.go
+++ b/internal/models/gcp_integration.go
@@ -1,0 +1,568 @@
+// Copyright Stacklet, Inc. 2025, 2026
+
+package models
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/stacklet/terraform-provider-stacklet/internal/api"
+	"github.com/stacklet/terraform-provider-stacklet/internal/errors"
+	"github.com/stacklet/terraform-provider-stacklet/internal/typehelpers"
+)
+
+// GCPIntegrationDataSource is the model for the GCP integration data source.
+type GCPIntegrationDataSource struct {
+	ID             types.String `tfsdk:"id"`
+	Key            types.String `tfsdk:"key"`
+	CustomerConfig types.Object `tfsdk:"customer_config"`
+	AccessConfig   types.Object `tfsdk:"access_config"`
+}
+
+func (m *GCPIntegrationDataSource) Update(integration *api.GCPIntegration) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	m.ID = types.StringValue(string(integration.ID))
+	m.Key = types.StringValue(integration.Key)
+
+	customerConfig, d := m.buildCustomerConfig(integration.CustomerConfig)
+	errors.AddAttributeDiags(&diags, d, "customer_config")
+	m.CustomerConfig = customerConfig
+
+	accessConfig, d := m.buildAccessConfig(integration.AccessConfig)
+	errors.AddAttributeDiags(&diags, d, "access_config")
+	m.AccessConfig = accessConfig
+
+	return diags
+}
+
+func (m GCPIntegrationDataSource) buildCustomerConfig(config api.GCPIntegrationCustomerConfig) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	nullObj := types.ObjectNull(GCPIntegrationCustomerConfigModel{}.AttributeTypes())
+
+	infrastructure, d := m.buildCustomerInfra(config.Infrastructure)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nullObj, diags
+	}
+
+	organizations, d := typehelpers.ObjectList[GCPIntegrationCustomerOrgModel](
+		config.Organizations,
+		func(org api.GCPIntegrationCustomerOrganization) (map[string]attr.Value, diag.Diagnostics) {
+			return map[string]attr.Value{
+				"org_id":      types.StringValue(org.OrgID),
+				"folder_ids":  typehelpers.StringsList(org.FolderIDs),
+				"project_ids": typehelpers.StringsList(org.ProjectIDs),
+			}, nil
+		},
+	)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nullObj, diags
+	}
+
+	costSources, d := typehelpers.ObjectList[GCPIntegrationCustomerCostSourceModel](
+		config.CostSources,
+		func(cs api.GCPIntegrationCustomerCostSource) (map[string]attr.Value, diag.Diagnostics) {
+			return map[string]attr.Value{
+				"billing_table": types.StringValue(cs.BillingTable),
+			}, nil
+		},
+	)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nullObj, diags
+	}
+
+	securityContexts, d := typehelpers.ObjectList[GCPIntegrationCustomerSecurityContextModel](
+		config.SecurityContexts,
+		func(sc api.GCPIntegrationCustomerSecurityContext) (map[string]attr.Value, diag.Diagnostics) {
+			return map[string]attr.Value{
+				"name":        types.StringValue(sc.Name),
+				"extra_roles": typehelpers.StringsList(sc.ExtraRoles),
+			}, nil
+		},
+	)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nullObj, diags
+	}
+
+	terraformModule, d := m.buildTerraformModule(config.TerraformModule)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nullObj, diags
+	}
+
+	return types.ObjectValue(
+		GCPIntegrationCustomerConfigModel{}.AttributeTypes(),
+		map[string]attr.Value{
+			"infrastructure":    infrastructure,
+			"organizations":     organizations,
+			"cost_sources":      costSources,
+			"security_contexts": securityContexts,
+			"terraform_module":  terraformModule,
+		},
+	)
+}
+
+func (m GCPIntegrationDataSource) buildCustomerInfra(infra *api.GCPIntegrationCustomerInfrastructure) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	nullObj := types.ObjectNull(GCPIntegrationCustomerInfraModel{}.AttributeTypes())
+
+	if infra == nil {
+		return nullObj, diags
+	}
+
+	createProject, d := m.buildCustomerCreateProject(infra.CreateProject)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nullObj, diags
+	}
+
+	return types.ObjectValue(
+		GCPIntegrationCustomerInfraModel{}.AttributeTypes(),
+		map[string]attr.Value{
+			"project_id":        types.StringValue(infra.ProjectID),
+			"resource_location": types.StringValue(infra.ResourceLocation),
+			"resource_prefix":   types.StringValue(infra.ResourcePrefix),
+			"create_project":    createProject,
+		},
+	)
+}
+
+func (m GCPIntegrationDataSource) buildCustomerCreateProject(cp *api.GCPIntegrationCustomerCreateProject) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	nullObj := types.ObjectNull(GCPIntegrationCustomerCreateProjectModel{}.AttributeTypes())
+
+	if cp == nil {
+		return nullObj, diags
+	}
+
+	labels, d := typehelpers.ObjectList[Tag](
+		cp.Labels,
+		func(t api.Tag) (map[string]attr.Value, diag.Diagnostics) {
+			return map[string]attr.Value{
+				"key":   types.StringValue(t.Key),
+				"value": types.StringValue(t.Value),
+			}, nil
+		},
+	)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nullObj, diags
+	}
+
+	return types.ObjectValue(
+		GCPIntegrationCustomerCreateProjectModel{}.AttributeTypes(),
+		map[string]attr.Value{
+			"billing_account_id": types.StringValue(cp.BillingAccountID),
+			"org_id":             types.StringPointerValue(cp.OrgID),
+			"folder_id":          types.StringPointerValue(cp.FolderID),
+			"labels":             labels,
+		},
+	)
+}
+
+func (m GCPIntegrationDataSource) buildTerraformModule(tm *api.TerraformModule) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	nullObj := types.ObjectNull(TerraformModule{}.AttributeTypes())
+
+	if tm == nil {
+		return nullObj, diags
+	}
+
+	return types.ObjectValue(
+		TerraformModule{}.AttributeTypes(),
+		map[string]attr.Value{
+			"repository_url": types.StringValue(tm.RepositoryURL),
+			"source":         types.StringValue(tm.Source),
+			"version":        types.StringPointerValue(tm.Version),
+			"variables_json": types.StringValue(tm.VariablesJSON),
+		},
+	)
+}
+
+func (m GCPIntegrationDataSource) buildAccessConfig(config *api.GCPIntegrationAccessConfig) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	nullObj := types.ObjectNull(GCPIntegrationAccessConfigModel{}.AttributeTypes())
+
+	if config == nil {
+		return nullObj, diags
+	}
+
+	infrastructure, d := m.buildAccessInfra(config.Infrastructure)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nullObj, diags
+	}
+
+	organizations, d := typehelpers.ObjectList[GCPIntegrationAccessOrgModel](
+		config.Organizations,
+		func(org api.GCPIntegrationAccessOrganization) (map[string]attr.Value, diag.Diagnostics) {
+			folders, d := typehelpers.ObjectList[GCPIntegrationAccessOrgFolderModel](
+				org.Folders,
+				func(f api.GCPIntegrationAccessOrganizationFolder) (map[string]attr.Value, diag.Diagnostics) {
+					return map[string]attr.Value{
+						"id":   types.StringValue(f.ID),
+						"name": types.StringValue(f.Name),
+					}, nil
+				},
+			)
+			if d.HasError() {
+				return make(map[string]attr.Value), d
+			}
+
+			projects, d := typehelpers.ObjectList[GCPIntegrationAccessOrgProjectModel](
+				org.Projects,
+				func(p api.GCPIntegrationAccessOrganizationProject) (map[string]attr.Value, diag.Diagnostics) {
+					return map[string]attr.Value{
+						"id":     types.StringValue(p.ID),
+						"number": types.StringValue(p.Number),
+					}, nil
+				},
+			)
+			if d.HasError() {
+				return make(map[string]attr.Value), d
+			}
+
+			return map[string]attr.Value{
+				"id":       types.StringValue(org.ID),
+				"name":     types.StringValue(org.Name),
+				"folders":  folders,
+				"projects": projects,
+			}, nil
+		},
+	)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nullObj, diags
+	}
+
+	costSources, d := typehelpers.ObjectList[GCPIntegrationAccessCostSourceModel](
+		config.CostSources,
+		func(cs api.GCPIntegrationAccessCostSource) (map[string]attr.Value, diag.Diagnostics) {
+			return map[string]attr.Value{
+				"billing_table": types.StringValue(cs.BillingTable),
+				"location":      types.StringValue(cs.Location),
+			}, nil
+		},
+	)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nullObj, diags
+	}
+
+	securityContexts, d := typehelpers.ObjectList[GCPIntegrationAccessSecurityContextModel](
+		config.SecurityContexts,
+		func(sc api.GCPIntegrationAccessSecurityContext) (map[string]attr.Value, diag.Diagnostics) {
+			return map[string]attr.Value{
+				"name":        types.StringValue(sc.Name),
+				"extra_roles": typehelpers.StringsList(sc.ExtraRoles),
+				"principal":   types.StringValue(sc.Principal),
+			}, nil
+		},
+	)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nullObj, diags
+	}
+
+	return types.ObjectValue(
+		GCPIntegrationAccessConfigModel{}.AttributeTypes(),
+		map[string]attr.Value{
+			"infrastructure":    infrastructure,
+			"organizations":     organizations,
+			"cost_sources":      costSources,
+			"security_contexts": securityContexts,
+			"roundtrip_digest":  types.StringValue(config.RoundtripDigest),
+		},
+	)
+}
+
+func (m GCPIntegrationDataSource) buildAccessInfra(infra api.GCPIntegrationAccessInfrastructure) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	nullObj := types.ObjectNull(GCPIntegrationAccessInfraModel{}.AttributeTypes())
+
+	relay, d := types.ObjectValue(
+		GCPIntegrationAccessRelayModel{}.AttributeTypes(),
+		map[string]attr.Value{
+			"oauth_id": types.StringValue(infra.Relay.OAuthID),
+		},
+	)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nullObj, diags
+	}
+
+	principals, d := types.ObjectValue(
+		GCPIntegrationAccessWIFPrincipalsModel{}.AttributeTypes(),
+		map[string]attr.Value{
+			"read_only":  types.StringValue(infra.WIF.Principals.ReadOnly),
+			"cost_query": types.StringValue(infra.WIF.Principals.CostQuery),
+		},
+	)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nullObj, diags
+	}
+
+	wif, d := types.ObjectValue(
+		GCPIntegrationAccessWIFModel{}.AttributeTypes(),
+		map[string]attr.Value{
+			"audience":   types.StringValue(infra.WIF.Audience),
+			"principals": principals,
+		},
+	)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nullObj, diags
+	}
+
+	return types.ObjectValue(
+		GCPIntegrationAccessInfraModel{}.AttributeTypes(),
+		map[string]attr.Value{
+			"project_id":     types.StringValue(infra.ProjectID),
+			"relay":          relay,
+			"wif":            wif,
+			"baseline_roles": typehelpers.StringsList(infra.BaselineRoles),
+		},
+	)
+}
+
+// GCPIntegrationCustomerConfigModel is the model for GCP integration customer configuration.
+type GCPIntegrationCustomerConfigModel struct {
+	Infrastructure   types.Object `tfsdk:"infrastructure"`
+	Organizations    types.List   `tfsdk:"organizations"`
+	CostSources      types.List   `tfsdk:"cost_sources"`
+	SecurityContexts types.List   `tfsdk:"security_contexts"`
+	TerraformModule  types.Object `tfsdk:"terraform_module"`
+}
+
+func (m GCPIntegrationCustomerConfigModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"infrastructure":    types.ObjectType{AttrTypes: GCPIntegrationCustomerInfraModel{}.AttributeTypes()},
+		"organizations":     types.ListType{ElemType: types.ObjectType{AttrTypes: GCPIntegrationCustomerOrgModel{}.AttributeTypes()}},
+		"cost_sources":      types.ListType{ElemType: types.ObjectType{AttrTypes: GCPIntegrationCustomerCostSourceModel{}.AttributeTypes()}},
+		"security_contexts": types.ListType{ElemType: types.ObjectType{AttrTypes: GCPIntegrationCustomerSecurityContextModel{}.AttributeTypes()}},
+		"terraform_module":  types.ObjectType{AttrTypes: TerraformModule{}.AttributeTypes()},
+	}
+}
+
+// GCPIntegrationCustomerInfraModel is the model for GCP integration customer infrastructure.
+type GCPIntegrationCustomerInfraModel struct {
+	ProjectID        types.String `tfsdk:"project_id"`
+	ResourceLocation types.String `tfsdk:"resource_location"`
+	ResourcePrefix   types.String `tfsdk:"resource_prefix"`
+	CreateProject    types.Object `tfsdk:"create_project"`
+}
+
+func (m GCPIntegrationCustomerInfraModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"project_id":        types.StringType,
+		"resource_location": types.StringType,
+		"resource_prefix":   types.StringType,
+		"create_project":    types.ObjectType{AttrTypes: GCPIntegrationCustomerCreateProjectModel{}.AttributeTypes()},
+	}
+}
+
+// GCPIntegrationCustomerCreateProjectModel is the model for GCP infrastructure project creation configuration.
+type GCPIntegrationCustomerCreateProjectModel struct {
+	BillingAccountID types.String `tfsdk:"billing_account_id"`
+	OrgID            types.String `tfsdk:"org_id"`
+	FolderID         types.String `tfsdk:"folder_id"`
+	Labels           types.List   `tfsdk:"labels"`
+}
+
+func (m GCPIntegrationCustomerCreateProjectModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"billing_account_id": types.StringType,
+		"org_id":             types.StringType,
+		"folder_id":          types.StringType,
+		"labels":             types.ListType{ElemType: types.ObjectType{AttrTypes: Tag{}.AttributeTypes()}},
+	}
+}
+
+// GCPIntegrationCustomerOrgModel is the model for a GCP customer organization.
+type GCPIntegrationCustomerOrgModel struct {
+	OrgID      types.String `tfsdk:"org_id"`
+	FolderIDs  types.List   `tfsdk:"folder_ids"`
+	ProjectIDs types.List   `tfsdk:"project_ids"`
+}
+
+func (m GCPIntegrationCustomerOrgModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"org_id":      types.StringType,
+		"folder_ids":  types.ListType{ElemType: types.StringType},
+		"project_ids": types.ListType{ElemType: types.StringType},
+	}
+}
+
+// GCPIntegrationCustomerCostSourceModel is the model for a GCP customer cost source.
+type GCPIntegrationCustomerCostSourceModel struct {
+	BillingTable types.String `tfsdk:"billing_table"`
+}
+
+func (m GCPIntegrationCustomerCostSourceModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"billing_table": types.StringType,
+	}
+}
+
+// GCPIntegrationCustomerSecurityContextModel is the model for a GCP customer security context.
+type GCPIntegrationCustomerSecurityContextModel struct {
+	Name       types.String `tfsdk:"name"`
+	ExtraRoles types.List   `tfsdk:"extra_roles"`
+}
+
+func (m GCPIntegrationCustomerSecurityContextModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name":        types.StringType,
+		"extra_roles": types.ListType{ElemType: types.StringType},
+	}
+}
+
+// GCPIntegrationAccessConfigModel is the model for GCP integration access configuration.
+type GCPIntegrationAccessConfigModel struct {
+	Infrastructure   types.Object `tfsdk:"infrastructure"`
+	Organizations    types.List   `tfsdk:"organizations"`
+	CostSources      types.List   `tfsdk:"cost_sources"`
+	SecurityContexts types.List   `tfsdk:"security_contexts"`
+	RoundtripDigest  types.String `tfsdk:"roundtrip_digest"`
+}
+
+func (m GCPIntegrationAccessConfigModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"infrastructure":    types.ObjectType{AttrTypes: GCPIntegrationAccessInfraModel{}.AttributeTypes()},
+		"organizations":     types.ListType{ElemType: types.ObjectType{AttrTypes: GCPIntegrationAccessOrgModel{}.AttributeTypes()}},
+		"cost_sources":      types.ListType{ElemType: types.ObjectType{AttrTypes: GCPIntegrationAccessCostSourceModel{}.AttributeTypes()}},
+		"security_contexts": types.ListType{ElemType: types.ObjectType{AttrTypes: GCPIntegrationAccessSecurityContextModel{}.AttributeTypes()}},
+		"roundtrip_digest":  types.StringType,
+	}
+}
+
+// GCPIntegrationAccessInfraModel is the model for GCP integration access infrastructure.
+type GCPIntegrationAccessInfraModel struct {
+	ProjectID     types.String `tfsdk:"project_id"`
+	Relay         types.Object `tfsdk:"relay"`
+	WIF           types.Object `tfsdk:"wif"`
+	BaselineRoles types.List   `tfsdk:"baseline_roles"`
+}
+
+func (m GCPIntegrationAccessInfraModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"project_id":     types.StringType,
+		"relay":          types.ObjectType{AttrTypes: GCPIntegrationAccessRelayModel{}.AttributeTypes()},
+		"wif":            types.ObjectType{AttrTypes: GCPIntegrationAccessWIFModel{}.AttributeTypes()},
+		"baseline_roles": types.ListType{ElemType: types.StringType},
+	}
+}
+
+// GCPIntegrationAccessRelayModel is the model for GCP integration relay configuration.
+type GCPIntegrationAccessRelayModel struct {
+	OAuthID types.String `tfsdk:"oauth_id"`
+}
+
+func (m GCPIntegrationAccessRelayModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"oauth_id": types.StringType,
+	}
+}
+
+// GCPIntegrationAccessWIFModel is the model for GCP Workload Identity Federation configuration.
+type GCPIntegrationAccessWIFModel struct {
+	Audience   types.String `tfsdk:"audience"`
+	Principals types.Object `tfsdk:"principals"`
+}
+
+func (m GCPIntegrationAccessWIFModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"audience":   types.StringType,
+		"principals": types.ObjectType{AttrTypes: GCPIntegrationAccessWIFPrincipalsModel{}.AttributeTypes()},
+	}
+}
+
+// GCPIntegrationAccessWIFPrincipalsModel is the model for WIF service account principals.
+type GCPIntegrationAccessWIFPrincipalsModel struct {
+	ReadOnly  types.String `tfsdk:"read_only"`
+	CostQuery types.String `tfsdk:"cost_query"`
+}
+
+func (m GCPIntegrationAccessWIFPrincipalsModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"read_only":  types.StringType,
+		"cost_query": types.StringType,
+	}
+}
+
+// GCPIntegrationAccessOrgModel is the model for a GCP accessible organization.
+type GCPIntegrationAccessOrgModel struct {
+	ID       types.String `tfsdk:"id"`
+	Name     types.String `tfsdk:"name"`
+	Folders  types.List   `tfsdk:"folders"`
+	Projects types.List   `tfsdk:"projects"`
+}
+
+func (m GCPIntegrationAccessOrgModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":       types.StringType,
+		"name":     types.StringType,
+		"folders":  types.ListType{ElemType: types.ObjectType{AttrTypes: GCPIntegrationAccessOrgFolderModel{}.AttributeTypes()}},
+		"projects": types.ListType{ElemType: types.ObjectType{AttrTypes: GCPIntegrationAccessOrgProjectModel{}.AttributeTypes()}},
+	}
+}
+
+// GCPIntegrationAccessOrgFolderModel is the model for a connected organization folder.
+type GCPIntegrationAccessOrgFolderModel struct {
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+func (m GCPIntegrationAccessOrgFolderModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":   types.StringType,
+		"name": types.StringType,
+	}
+}
+
+// GCPIntegrationAccessOrgProjectModel is the model for a connected organization project.
+type GCPIntegrationAccessOrgProjectModel struct {
+	ID     types.String `tfsdk:"id"`
+	Number types.String `tfsdk:"number"`
+}
+
+func (m GCPIntegrationAccessOrgProjectModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":     types.StringType,
+		"number": types.StringType,
+	}
+}
+
+// GCPIntegrationAccessCostSourceModel is the model for a GCP access cost source.
+type GCPIntegrationAccessCostSourceModel struct {
+	BillingTable types.String `tfsdk:"billing_table"`
+	Location     types.String `tfsdk:"location"`
+}
+
+func (m GCPIntegrationAccessCostSourceModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"billing_table": types.StringType,
+		"location":      types.StringType,
+	}
+}
+
+// GCPIntegrationAccessSecurityContextModel is the model for a GCP access security context.
+type GCPIntegrationAccessSecurityContextModel struct {
+	Name       types.String `tfsdk:"name"`
+	ExtraRoles types.List   `tfsdk:"extra_roles"`
+	Principal  types.String `tfsdk:"principal"`
+}
+
+func (m GCPIntegrationAccessSecurityContextModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name":        types.StringType,
+		"extra_roles": types.ListType{ElemType: types.StringType},
+		"principal":   types.StringType,
+	}
+}


### PR DESCRIPTION
[ENG-6977](https://stacklet.atlassian.net/browse/ENG-6977)

### what

add datasource to read GCP integration configuration

### why

provide a way to get current configuration

### testing

local testing, will add integration test once there's a corresponding resource too

### docs

not yet, since it's not official yet


[ENG-6977]: https://stacklet.atlassian.net/browse/ENG-6977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ