### PR TITLE
chore: wrap graphql client in the API module

### DIFF
--- a/internal/api/account.go
+++ b/internal/api/account.go
@@ -56,7 +56,7 @@ func (i AccountUpdateInput) GetGraphQLType() string {
 }
 
 type accountAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // Read returns data for an account.
@@ -69,7 +69,7 @@ func (a accountAPI) Read(ctx context.Context, cloudProvider string, key string) 
 		"key":      graphql.String(key),
 	}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if query.Account.ID == "" || !query.Account.Active {
@@ -88,7 +88,7 @@ func (a accountAPI) Create(ctx context.Context, i AccountCreateInput) (*Account,
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	return &mutation.Payload.Account, nil
@@ -103,7 +103,7 @@ func (a accountAPI) Update(ctx context.Context, i AccountUpdateInput) (*Account,
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	return &mutation.Payload.Account, nil
@@ -123,7 +123,7 @@ func (a accountAPI) Delete(ctx context.Context, cloudProvider string, key string
 		"key":      graphql.String(key),
 	}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return NewAPIError(err)
+		return err
 	}
 	return nil
 }

--- a/internal/api/account_discovery.go
+++ b/internal/api/account_discovery.go
@@ -109,7 +109,7 @@ type accountDiscoveryScheduleInput struct {
 }
 
 type accountDiscoveryAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // Read returns data for an account discovery.
@@ -119,7 +119,7 @@ func (a accountDiscoveryAPI) Read(ctx context.Context, name string) (*AccountDis
 	}
 	variables := map[string]any{"name": graphql.String(name)}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if query.AccountDiscovery.ID == "" {
@@ -138,7 +138,7 @@ func (a accountDiscoveryAPI) UpsertAWS(ctx context.Context, input AccountDiscove
 	}
 	variables := map[string]any{"input": input}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 	return &mutation.Payload.AccountDiscovery, nil
 }
@@ -152,7 +152,7 @@ func (a accountDiscoveryAPI) UpsertAzure(ctx context.Context, input AccountDisco
 	}
 	variables := map[string]any{"input": input}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 	return &mutation.Payload.AccountDiscovery, nil
 }
@@ -166,7 +166,7 @@ func (a accountDiscoveryAPI) UpsertGCP(ctx context.Context, input AccountDiscove
 	}
 	variables := map[string]any{"input": input}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 	return &mutation.Payload.AccountDiscovery, nil
 }
@@ -175,12 +175,12 @@ func (a accountDiscoveryAPI) UpsertGCP(ctx context.Context, input AccountDiscove
 func (a accountDiscoveryAPI) Remove(ctx context.Context, id string) error {
 	var mutation struct {
 		Payload struct {
-			Problems []Problem
+			Problems []problem
 		} `graphql:"removeAccountDiscovery(input: $input)"`
 	}
 	variables := map[string]any{"input": accountDiscoveryRemoveInput{ID: graphql.ID(id)}}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return NewAPIError(err)
+		return err
 	}
 	return fromProblems(ctx, mutation.Payload.Problems)
 }
@@ -203,7 +203,7 @@ func (a accountDiscoveryAPI) UpdateSuspended(ctx context.Context, id string, sus
 		},
 	}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	return &mutation.Payload.AccountDiscoveries[0], nil

--- a/internal/api/account_group.go
+++ b/internal/api/account_group.go
@@ -47,7 +47,7 @@ func (i AccountGroupUpdateInput) GetGraphQLType() string {
 }
 
 type accountGroupAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // Read returns data for an account group.
@@ -61,7 +61,7 @@ func (a accountGroupAPI) Read(ctx context.Context, uuid string, name string) (*A
 		"name": graphql.String(name),
 	}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if query.AccountGroup.ID == "" {
@@ -80,7 +80,7 @@ func (a accountGroupAPI) Create(ctx context.Context, i AccountGroupCreateInput) 
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	return &mutation.Payload.Group, nil
@@ -95,7 +95,7 @@ func (a accountGroupAPI) Update(ctx context.Context, i AccountGroupUpdateInput) 
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	return &mutation.Payload.Group, nil
@@ -112,7 +112,7 @@ func (a accountGroupAPI) Delete(ctx context.Context, uuid string) error {
 	}
 	variables := map[string]any{"uuid": graphql.String(uuid)}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return NewAPIError(err)
+		return err
 	}
 	return nil
 }

--- a/internal/api/account_group_mapping.go
+++ b/internal/api/account_group_mapping.go
@@ -41,7 +41,7 @@ func (i removeAccountGroupMappingsInput) GetGraphQLType() string {
 }
 
 type accountGroupMappingAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // Read returns data for an account group mapping.
@@ -66,7 +66,7 @@ func (a accountGroupMappingAPI) Read(ctx context.Context, accountKey string, gro
 	}
 
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if len(query.AccountGroup.AccountMappings.Edges) == 0 {
@@ -103,7 +103,7 @@ func (a accountGroupMappingAPI) Create(ctx context.Context, accountKey string, g
 
 	err := a.c.Mutate(ctx, &mutation, variables)
 	if err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	return &AccountGroupMapping{
@@ -128,7 +128,7 @@ func (a accountGroupMappingAPI) Delete(ctx context.Context, id string) error {
 		},
 	}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return NewAPIError(err)
+		return err
 	}
 	return nil
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -4,7 +4,7 @@
 package api
 
 import (
-	"github.com/hasura/go-graphql-client"
+	"context"
 )
 
 // API provides access to the GraphQL API.
@@ -30,7 +30,8 @@ type API struct {
 }
 
 // New creates an API wrapper.
-func New(c *graphql.Client) *API {
+func New(ctx context.Context, config ClientConfig) *API {
+	c := newClient(ctx, config)
 	return &API{
 		Account:                 accountAPI{c},
 		AccountDiscovery:        accountDiscoveryAPI{c},

--- a/internal/api/binding.go
+++ b/internal/api/binding.go
@@ -129,7 +129,7 @@ func (i BindingUpdateInput) GetGraphQLType() string {
 }
 
 type bindingAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // Read returns data for a binding.
@@ -142,7 +142,7 @@ func (a bindingAPI) Read(ctx context.Context, uuid string, name string) (*Bindin
 		"name": graphql.String(name),
 	}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 	if query.Binding.ID == "" {
 		return nil, NotFound{"Binding not found"}
@@ -160,7 +160,7 @@ func (a bindingAPI) Create(ctx context.Context, i BindingCreateInput) (*Binding,
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	return &mutation.Payload.Binding, nil
@@ -175,7 +175,7 @@ func (a bindingAPI) Update(ctx context.Context, i BindingUpdateInput) (*Binding,
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	return &mutation.Payload.Binding, nil
@@ -194,7 +194,7 @@ func (a bindingAPI) Delete(ctx context.Context, uuid string) error {
 		"uuid": graphql.String(uuid),
 	}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return NewAPIError(err)
+		return err
 	}
 	return nil
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -15,15 +15,45 @@ import (
 	"github.com/hasura/go-graphql-client"
 )
 
-// NewClient returns a configured graphql Client.
-func NewClient(ctx context.Context, endpoint string, apiKey string, version string) *graphql.Client {
+// / ClientConfig is the configuration for the API client.
+type ClientConfig struct {
+	Endpoint string
+	APIKey   string
+	Version  string
+}
+
+// client is the wrapper for the GraphQL client.
+type client struct {
+	c *graphql.Client
+}
+
+// Query makes a GraphQL query call.
+func (c *client) Query(ctx context.Context, q any, variables map[string]any) error {
+	err := c.c.Query(ctx, q, variables)
+	if err != nil {
+		return newAPIError(err)
+	}
+	return nil
+}
+
+// Mutate makes a GraphQL mutation call.
+func (c *client) Mutate(ctx context.Context, m any, variables map[string]any) error {
+	err := c.c.Mutate(ctx, m, variables)
+	if err != nil {
+		return newAPIError(err)
+	}
+	return nil
+}
+
+// newClient returns a configured graphql Client.
+func newClient(ctx context.Context, config ClientConfig) *client {
 	tfLog := hclog.LevelFromString(os.Getenv("TF_LOG"))
 	logBody := tfLog == hclog.Debug || tfLog == hclog.Trace
 
 	httpClient := &http.Client{
 		Transport: &authTransport{
-			APIKey:  apiKey,
-			Version: version,
+			APIKey:  config.APIKey,
+			Version: config.Version,
 			Base: &logTransport{
 				Ctx:     ctx,
 				Base:    http.DefaultTransport,
@@ -31,7 +61,7 @@ func NewClient(ctx context.Context, endpoint string, apiKey string, version stri
 			},
 		},
 	}
-	return graphql.NewClient(endpoint, httpClient)
+	return &client{c: graphql.NewClient(config.Endpoint, httpClient)}
 }
 
 // authTransport is an http.Transport that adds authorization header.

--- a/internal/api/configuration_profile.go
+++ b/internal/api/configuration_profile.go
@@ -289,7 +289,7 @@ func (i emailConfigurationInput) GetGraphQLType() string {
 }
 
 type configurationProfileAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 const configurationScopeGlobal = "0"
@@ -304,7 +304,7 @@ func (a configurationProfileAPI) Read(ctx context.Context, name ConfigurationPro
 		"scope": graphql.String(configurationScopeGlobal),
 	}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if query.Configuration.ID == "" {
@@ -370,7 +370,7 @@ func (a configurationProfileAPI) UpsertJira(ctx context.Context, input JiraConfi
 	}
 
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if mutation.Payload.Configuration.ID == "" {
@@ -395,7 +395,7 @@ func (a configurationProfileAPI) UpsertAccountOwners(ctx context.Context, input 
 		},
 	}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if mutation.Payload.Configuration.ID == "" {
@@ -420,7 +420,7 @@ func (a configurationProfileAPI) UpsertResourceOwner(ctx context.Context, input 
 		},
 	}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if mutation.Payload.Configuration.ID == "" {
@@ -446,7 +446,7 @@ func (a configurationProfileAPI) UpsertSlack(ctx context.Context, config SlackCo
 	}
 
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if mutation.Payload.Configuration.ID == "" {
@@ -472,7 +472,7 @@ func (a configurationProfileAPI) UpsertServiceNow(ctx context.Context, config Se
 	}
 
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if mutation.Payload.Configuration.ID == "" {
@@ -498,7 +498,7 @@ func (a configurationProfileAPI) UpsertSymphony(ctx context.Context, config Symp
 	}
 
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if mutation.Payload.Configuration.ID == "" {
@@ -524,7 +524,7 @@ func (a configurationProfileAPI) UpsertEmail(ctx context.Context, input EmailCon
 	}
 
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if mutation.Payload.Configuration.ID == "" {
@@ -550,7 +550,7 @@ func (a configurationProfileAPI) UpsertMSTeams(ctx context.Context, input MSTeam
 	}
 
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if mutation.Payload.Configuration.ID == "" {
@@ -570,7 +570,7 @@ func (a configurationProfileAPI) Delete(ctx context.Context, name ConfigurationP
 		"scope": graphql.String(configurationScopeGlobal),
 	}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return NewAPIError(err)
+		return err
 	}
 	return nil
 }

--- a/internal/api/error.go
+++ b/internal/api/error.go
@@ -8,25 +8,25 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// APIError represent an error interacting with the API.
-type APIError struct {
+// apiError represent an error interacting with the API.
+type apiError struct {
 	Kind   string
 	Detail string
 }
 
 // Error returns the error summary message.
-func (e APIError) Summary() string {
+func (e apiError) Summary() string {
 	return e.Kind
 }
 
 // Error returns the error message.
-func (e APIError) Error() string {
+func (e apiError) Error() string {
 	return e.Detail
 }
 
-// newAPIError returns an APIError from an error.
-func NewAPIError(err error) APIError {
-	return APIError{Kind: "API Error", Detail: err.Error()}
+// newAPIError returns an apiError from an error.
+func newAPIError(err error) apiError {
+	return apiError{Kind: "API Error", Detail: err.Error()}
 }
 
 // NotFound represents an error raised when an API resource is not found.
@@ -45,7 +45,7 @@ func (e NotFound) Error() string {
 }
 
 // fromProblems returns an error from a list of API problems.
-func fromProblems(ctx context.Context, problems []Problem) error {
+func fromProblems(ctx context.Context, problems []problem) error {
 	if len(problems) == 0 {
 		return nil
 	}
@@ -56,11 +56,11 @@ func fromProblems(ctx context.Context, problems []Problem) error {
 	if problems[0].Kind == "NotFound" {
 		return NotFound{problems[0].Message}
 	}
-	return APIError{Kind: problems[0].Kind, Detail: problems[0].Message}
+	return apiError{Kind: problems[0].Kind, Detail: problems[0].Message}
 }
 
-// Problem contains the details for an API query error.
-type Problem struct {
+// problem contains the details for an API query error.
+type problem struct {
 	Kind    string `graphql:"__typename"`
 	Message string
 }

--- a/internal/api/gcp_integration.go
+++ b/internal/api/gcp_integration.go
@@ -132,7 +132,7 @@ type GCPIntegrationAccessSecurityContext struct {
 }
 
 type gcpIntegrationAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // Read returns data for a GCP integration by key.
@@ -140,11 +140,11 @@ func (a gcpIntegrationAPI) Read(ctx context.Context, key string) (*GCPIntegratio
 	var query struct {
 		Payload struct {
 			GCPIntegration *GCPIntegration `graphql:"gcpIntegration"`
-			Problems       []Problem
+			Problems       []problem
 		} `graphql:"gcpIntegration(key: $key)"`
 	}
 	if err := a.c.Query(ctx, &query, map[string]any{"key": graphql.String(key)}); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 	if err := fromProblems(ctx, query.Payload.Problems); err != nil {
 		return nil, err

--- a/internal/api/notification_template.go
+++ b/internal/api/notification_template.go
@@ -26,7 +26,7 @@ type TemplateInput struct {
 }
 
 type templateAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // Read returns data for a notification template.
@@ -36,7 +36,7 @@ func (a templateAPI) Read(ctx context.Context, name string) (*Template, error) {
 	}
 
 	if err := a.c.Query(ctx, &query, map[string]any{"name": graphql.String(name)}); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 	if query.Template.ID == "" {
 		return nil, NotFound{"Template not found"}
@@ -54,7 +54,7 @@ func (a templateAPI) Upsert(ctx context.Context, input TemplateInput) (*Template
 	}
 	err := a.c.Mutate(ctx, &mutation, map[string]any{"input": input})
 	if err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	return &mutation.Payload.Template, nil
@@ -66,7 +66,7 @@ func (a templateAPI) Delete(ctx context.Context, name string) error {
 		ID string `graphql:"removeTemplate(name: $name)"`
 	}
 	if err := a.c.Mutate(ctx, &mutation, map[string]any{"name": graphql.String(name)}); err != nil {
-		return NewAPIError(err)
+		return err
 	}
 	return nil
 }

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -27,7 +27,7 @@ type Policy struct {
 }
 
 type policyAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // Read returns data for a policy.
@@ -41,7 +41,7 @@ func (a policyAPI) Read(ctx context.Context, uuid string, name string, version i
 		"version": graphql.Int(version),
 	}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if query.Policy.ID == "" {

--- a/internal/api/policy_collection.go
+++ b/internal/api/policy_collection.go
@@ -67,7 +67,7 @@ type RepositoryViewInput struct {
 }
 
 type policyCollectionAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // Read returns data for an account.
@@ -80,7 +80,7 @@ func (a policyCollectionAPI) Read(ctx context.Context, uuid string, name string)
 		"name": graphql.String(name),
 	}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if query.PolicyCollection.ID == "" {
@@ -99,7 +99,7 @@ func (a policyCollectionAPI) Create(ctx context.Context, i PolicyCollectionCreat
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 	return &mutation.Payload.Collection, nil
 }
@@ -113,7 +113,7 @@ func (a policyCollectionAPI) Update(ctx context.Context, i PolicyCollectionUpdat
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	return &mutation.Payload.Collection, nil
@@ -132,7 +132,7 @@ func (a policyCollectionAPI) Delete(ctx context.Context, uuid string) error {
 		"uuid": graphql.String(uuid),
 	}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return NewAPIError(err)
+		return err
 	}
 	return nil
 }

--- a/internal/api/policy_collection_mapping.go
+++ b/internal/api/policy_collection_mapping.go
@@ -48,7 +48,7 @@ func (i removePolicyCollectionMappingInput) GetGraphQLType() string {
 }
 
 type policyCollectionMappingAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // Read returns data for a policy collection mapping.
@@ -59,7 +59,7 @@ func (a policyCollectionMappingAPI) Read(ctx context.Context, collectionUUID str
 				Edges []struct {
 					Node PolicyCollectionMapping
 				}
-				Problems []Problem
+				Problems []problem
 			} `graphql:"policyMappings(filterElement: $policyFilter)"`
 		} `graphql:"policyCollection(uuid: $uuid)"`
 	}
@@ -68,7 +68,7 @@ func (a policyCollectionMappingAPI) Read(ctx context.Context, collectionUUID str
 		"policyFilter": newExactMatchFilter("uuid", policyUUID),
 	}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 	if err := fromProblems(ctx, query.PolicyCollection.PolicyMappings.Problems); err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func (a policyCollectionMappingAPI) Upsert(ctx context.Context, input PolicyColl
 
 	err := a.c.Mutate(ctx, &mutation, variables)
 	if err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	return &mutation.Payload.Mappings[0], nil
@@ -117,7 +117,7 @@ func (a policyCollectionMappingAPI) Delete(ctx context.Context, id string) error
 		},
 	}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return NewAPIError(err)
+		return err
 	}
 	return nil
 }

--- a/internal/api/report_group.go
+++ b/internal/api/report_group.go
@@ -182,7 +182,7 @@ func (i upsertReportGroupsInput) GetGraphQLType() string {
 }
 
 type reportGroupAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // Read returns data for a report group.
@@ -192,7 +192,7 @@ func (a reportGroupAPI) Read(ctx context.Context, name string) (*ReportGroup, er
 	}
 
 	if err := a.c.Query(ctx, &query, map[string]any{"name": graphql.String(name)}); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if query.ReportGroup.ID == "" {
@@ -215,7 +215,7 @@ func (a reportGroupAPI) Upsert(ctx context.Context, input ReportGroupInput) (*Re
 		},
 	}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if len(mutation.Payload.ReportGroups) == 0 {
@@ -230,7 +230,7 @@ func (a reportGroupAPI) Delete(ctx context.Context, name string) error {
 		IDs []string `graphql:"removeReportGroups(names: $names)"`
 	}
 	if err := a.c.Mutate(ctx, &mutation, map[string]any{"names": []graphql.String{graphql.String(name)}}); err != nil {
-		return NewAPIError(err)
+		return err
 	}
 	return nil
 }

--- a/internal/api/repository.go
+++ b/internal/api/repository.go
@@ -103,18 +103,18 @@ func (i RepositoryDeleteInput) GetGraphQLType() string {
 }
 
 type repositoryAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 func (a repositoryAPI) Read(ctx context.Context, uuid string) (*Repository, error) {
 	var q struct {
 		Payload struct {
 			RepositoryConfig Repository
-			Problems         []Problem
+			Problems         []problem
 		} `graphql:"repositoryConfig(uuid: $uuid)"`
 	}
 	if err := a.c.Query(ctx, &q, map[string]any{"uuid": uuid}); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 	if err := fromProblems(ctx, q.Payload.Problems); err != nil {
 		return nil, err
@@ -136,13 +136,13 @@ func (a repositoryAPI) FindByURL(ctx context.Context, url string) (string, error
 				HasNextPage bool
 				EndCursor   string
 			}
-			Problems []Problem
+			Problems []problem
 		} `graphql:"repositoryConfigs(first: 100, after: $cursor)"`
 	}
 	for {
 		variables := map[string]any{"cursor": graphql.String(cursor)}
 		if err := a.c.Query(ctx, &q, variables); err != nil {
-			return "", NewAPIError(err)
+			return "", err
 		}
 		if err := fromProblems(ctx, q.Conn.Problems); err != nil {
 			return "", err
@@ -163,11 +163,11 @@ func (a repositoryAPI) Create(ctx context.Context, i RepositoryCreateInput) (*Re
 	var m struct {
 		Payload struct {
 			RepositoryConfig Repository
-			Problems         []Problem
+			Problems         []problem
 		} `graphql:"addRepositoryConfig(input: $input)"`
 	}
 	if err := a.c.Mutate(ctx, &m, map[string]any{"input": i}); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 	if err := fromProblems(ctx, m.Payload.Problems); err != nil {
 		return nil, err
@@ -179,11 +179,11 @@ func (a repositoryAPI) Update(ctx context.Context, i RepositoryUpdateInput) (*Re
 	var m struct {
 		Payload struct {
 			RepositoryConfig Repository
-			Problems         []Problem
+			Problems         []problem
 		} `graphql:"updateRepositoryConfig(input: $input)"`
 	}
 	if err := a.c.Mutate(ctx, &m, map[string]any{"input": i}); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 	if err := fromProblems(ctx, m.Payload.Problems); err != nil {
 		return nil, err
@@ -194,11 +194,11 @@ func (a repositoryAPI) Update(ctx context.Context, i RepositoryUpdateInput) (*Re
 func (a repositoryAPI) Delete(ctx context.Context, i RepositoryDeleteInput) error {
 	var m struct {
 		Payload struct {
-			Problems []Problem
+			Problems []problem
 		} `graphql:"removeRepositoryConfig(input: $input)"`
 	}
 	if err := a.c.Mutate(ctx, &m, map[string]any{"input": i}); err != nil {
-		return NewAPIError(err)
+		return err
 	}
 	if err := fromProblems(ctx, m.Payload.Problems); err != nil {
 		return err

--- a/internal/api/role.go
+++ b/internal/api/role.go
@@ -17,7 +17,7 @@ type Role struct {
 }
 
 type roleAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // Read returns data for a role by name.
@@ -33,7 +33,7 @@ func (r roleAPI) Read(ctx context.Context, name string) (*Role, error) {
 		"filterElement": newExactMatchFilter("name", name),
 	}
 	if err := r.c.Query(ctx, &query, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if len(query.Roles.Edges) == 0 {
@@ -67,7 +67,7 @@ func (r roleAPI) List(ctx context.Context) ([]Role, error) {
 		}
 
 		if err := r.c.Query(ctx, &query, variables); err != nil {
-			return nil, NewAPIError(err)
+			return nil, err
 		}
 
 		for _, edge := range query.Roles.Edges {

--- a/internal/api/role_assignment.go
+++ b/internal/api/role_assignment.go
@@ -60,7 +60,7 @@ func (r *RoleAssignment) GetTarget() string {
 }
 
 type roleAssignmentAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // RoleAssignmentInput represents the input for granting or revoking a role assignment.
@@ -134,7 +134,7 @@ func (r roleAssignmentAPI) Create(ctx context.Context, roleName string, principa
 	}
 
 	if err := r.c.Mutate(ctx, &mutation, map[string]any{"input": input}); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if len(mutation.UpdateRoleAssignment.Grant) == 0 {
@@ -143,7 +143,7 @@ func (r roleAssignmentAPI) Create(ctx context.Context, roleName string, principa
 
 	grantPayload := mutation.UpdateRoleAssignment.Grant[0]
 	if grantPayload.Error() != "" {
-		return nil, NewAPIError(fmt.Errorf("failed to grant role assignment: %w", grantPayload))
+		return nil, newAPIError(fmt.Errorf("failed to grant role assignment: %w", grantPayload))
 	}
 
 	if grantPayload.RoleAssignment == nil {
@@ -198,14 +198,14 @@ func (r roleAssignmentAPI) Delete(ctx context.Context, roleName string, principa
 	}
 
 	if err := r.c.Mutate(ctx, &mutation, variables); err != nil {
-		return NewAPIError(err)
+		return err
 	}
 
 	// Check if we have a revoke result with an error
 	if len(mutation.UpdateRoleAssignment.Revoke) > 0 {
 		revokePayload := mutation.UpdateRoleAssignment.Revoke[0]
 		if revokePayload.Error() != "" {
-			return NewAPIError(fmt.Errorf("failed to revoke role assignment: %w", revokePayload))
+			return newAPIError(fmt.Errorf("failed to revoke role assignment: %w", revokePayload))
 		}
 	}
 
@@ -237,7 +237,7 @@ func (r roleAssignmentAPI) List(ctx context.Context, target *string, principal *
 		}
 
 		if err := r.c.Query(ctx, &query, variables); err != nil {
-			return nil, NewAPIError(err)
+			return nil, err
 		}
 
 		for _, edge := range query.RoleAssignments.Edges {

--- a/internal/api/sso_group.go
+++ b/internal/api/sso_group.go
@@ -5,8 +5,6 @@ package api
 import (
 	"context"
 	"fmt"
-
-	"github.com/hasura/go-graphql-client"
 )
 
 // SSOGroup is the data returned by reading SSO group data.
@@ -69,7 +67,7 @@ func (i removeSSOGroupsInput) GetGraphQLType() string {
 }
 
 type ssoGroupAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // Read returns data for an SSO group by name.
@@ -87,7 +85,7 @@ func (a ssoGroupAPI) Read(ctx context.Context, name string) (*SSOGroup, error) {
 		"filterElement": newSimpleFilter("name", name),
 	}
 	if err := a.c.Query(ctx, &query, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if len(query.SSOGroups.Edges) == 0 {
@@ -110,7 +108,7 @@ func (a ssoGroupAPI) Upsert(ctx context.Context, input SSOGroupInput) (*SSOGroup
 		},
 	}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if len(mutation.Payload.Response) == 0 {
@@ -118,7 +116,7 @@ func (a ssoGroupAPI) Upsert(ctx context.Context, input SSOGroupInput) (*SSOGroup
 	}
 	payload := mutation.Payload.Response[0]
 	if payload.Error() != "" {
-		return nil, NewAPIError(fmt.Errorf("failed to upsert SSO group: %w", payload))
+		return nil, newAPIError(fmt.Errorf("failed to upsert SSO group: %w", payload))
 	}
 	if payload.SSOGroup == nil {
 		return nil, NotFound{"SSO group not found after upsert"}
@@ -137,12 +135,12 @@ func (a ssoGroupAPI) Delete(ctx context.Context, name string) error {
 		"input": removeSSOGroupsInput{Names: []string{name}},
 	}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return NewAPIError(err)
+		return err
 	}
 	if len(mutation.Payload.Response) > 0 {
 		payload := mutation.Payload.Response[0]
 		if payload.Error() != "" {
-			return NewAPIError(fmt.Errorf("failed to remove SSO group: %w", payload))
+			return newAPIError(fmt.Errorf("failed to remove SSO group: %w", payload))
 		}
 	}
 	return nil

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -4,8 +4,6 @@ package api
 
 import (
 	"context"
-
-	"github.com/hasura/go-graphql-client"
 )
 
 // Platform is the data returned by reading platform data.
@@ -52,7 +50,7 @@ type GCPIntegrationSurfaceAwsRelay struct {
 }
 
 type systemAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // Platform returns platform details.
@@ -61,7 +59,7 @@ func (a systemAPI) Platform(ctx context.Context) (*Platform, error) {
 		Platform Platform `graphql:"platform"`
 	}
 	if err := a.c.Query(ctx, &query, nil); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 	return &query.Platform, nil
 }
@@ -72,7 +70,7 @@ func (a systemAPI) MSTeamsIntegrationSurface(ctx context.Context) (*MSTeamsInteg
 		MSTeamsIntegrationSurface MSTeamsIntegrationSurface `graphql:"msTeamsIntegrationSurface"`
 	}
 	if err := a.c.Query(ctx, &query, nil); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 	return &query.MSTeamsIntegrationSurface, nil
 }
@@ -83,7 +81,7 @@ func (a systemAPI) GCPIntegrationSurface(ctx context.Context) (*GCPIntegrationSu
 		GCPIntegrationSurface GCPIntegrationSurface `graphql:"gcpIntegrationSurface"`
 	}
 	if err := a.c.Query(ctx, &query, nil); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 	return &query.GCPIntegrationSurface, nil
 }

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -48,7 +48,7 @@ func (i UserUpdateInput) GetGraphQLType() string {
 }
 
 type userAPI struct {
-	c *graphql.Client
+	c *client
 }
 
 // Read returns data for a user by username.
@@ -66,7 +66,7 @@ func (u userAPI) Read(ctx context.Context, username string) (*User, error) {
 		"filterElement": newSimpleFilter("username", username),
 	}
 	if err := u.c.Query(ctx, &query, variables); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	if len(query.Users.Edges) == 0 {
@@ -86,7 +86,7 @@ func (a userAPI) Create(ctx context.Context, i UserCreateInput) (*User, error) {
 
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	return &mutation.Payload.User, nil
@@ -101,7 +101,7 @@ func (a userAPI) Update(ctx context.Context, i UserUpdateInput) (*User, error) {
 	}
 	input := map[string]any{"input": i}
 	if err := a.c.Mutate(ctx, &mutation, input); err != nil {
-		return nil, NewAPIError(err)
+		return nil, err
 	}
 
 	return &mutation.Payload.User, nil
@@ -118,7 +118,7 @@ func (a userAPI) Delete(ctx context.Context, key int64) error {
 	}
 	variables := map[string]any{"key": graphql.Int(key)}
 	if err := a.c.Mutate(ctx, &mutation, variables); err != nil {
-		return NewAPIError(err)
+		return err
 	}
 	return nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -141,7 +141,14 @@ func (p *stackletProvider) Configure(ctx context.Context, req provider.Configure
 	}
 
 	// Make provider data accessible to the Configure method of resources and data sources
-	providerData := providerdata.New(api.NewClient(ctx, creds.Endpoint, creds.APIKey, p.version))
+	providerData := providerdata.New(
+		ctx,
+		api.ClientConfig{
+			Endpoint: creds.Endpoint,
+			APIKey:   creds.APIKey,
+			Version:  p.version,
+		},
+	)
 	resp.ResourceData = providerData
 	resp.DataSourceData = providerData
 

--- a/internal/providerdata/providerdata.go
+++ b/internal/providerdata/providerdata.go
@@ -3,11 +3,11 @@
 package providerdata
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hasura/go-graphql-client"
 
 	"github.com/stacklet/terraform-provider-stacklet/internal/api"
 )
@@ -18,9 +18,9 @@ type providerData struct {
 }
 
 // New returns configured provider data.
-func New(client *graphql.Client) *providerData {
+func New(ctx context.Context, config api.ClientConfig) *providerData {
 	return &providerData{
-		API: api.New(client),
+		API: api.New(ctx, config),
 	}
 }
 


### PR DESCRIPTION
### what

add a wrapper for the graphql client exposing the Query/Mutate methods with API
error wrapping, pass structured config to the API package

### why

This simplifies the external API as the caller can create the API struct by
passing a single struct object.
Also removes the need for the APIError wrapping in each call sites in API methods

### testing

all tests still pass

### docs

n/a
