### PR TITLE
chore: add pre-commit linting, harden CI permissions, fix typos

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -8,6 +8,7 @@ project {
     ".github/**",
     ".golangci.yaml",
     ".goreleaser.yaml",
+    ".pre-commit-config.yaml",
     "examples/**",
     "go.*",
   ]

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+paths:
+  .github/workflows/release.yaml:
+    ignore:
+      - 'constant expression "false" in condition'

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,22 +1,25 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: chore
 
   - package-ecosystem: gomod
-    directory: /
+    directories:
+      - "/"
+      - "/tools"
     schedule:
-      interval: weekly
-    commit-message:
-      prefix: chore
-
-  - package-ecosystem: gomod
-    directory: /tools
-    schedule:
-      interval: weekly
+      interval: "monthly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: chore

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Tool versions
         uses: wistia/parse-tool-versions@32f568a4ffd4bfa7720ebf93f171597d1ebc979a # v2.1.1
@@ -39,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Tool versions
         uses: wistia/parse-tool-versions@32f568a4ffd4bfa7720ebf93f171597d1ebc979a # v2.1.1
@@ -64,11 +68,42 @@ jobs:
         run: |
           just lint-tf
 
+  lint-pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Tool versions
+        uses: wistia/parse-tool-versions@32f568a4ffd4bfa7720ebf93f171597d1ebc979a # v2.1.1
+        with:
+          postfix: _TOOL_VERSION
+
+      - name: Setup Just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        with:
+          just-version: ${{ env.JUST_TOOL_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: ${{ env.UV_TOOL_VERSION }}
+          activate-environment: true
+          enable-cache: true
+
+      - name: Lint
+        run: |
+          just lint-pre-commit
+
   lint-docs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Tool versions
         uses: wistia/parse-tool-versions@32f568a4ffd4bfa7720ebf93f171597d1ebc979a # v2.1.1
@@ -96,6 +131,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Tool versions
         uses: wistia/parse-tool-versions@32f568a4ffd4bfa7720ebf93f171597d1ebc979a # v2.1.1
@@ -121,6 +157,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Tool versions
         uses: wistia/parse-tool-versions@32f568a4ffd4bfa7720ebf93f171597d1ebc979a # v2.1.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,17 +10,20 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Tool versions
         uses: wistia/parse-tool-versions@32f568a4ffd4bfa7720ebf93f171597d1ebc979a # v2.1.1
@@ -31,6 +34,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GOLANG_TOOL_VERSION }}
+          cache: false
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
@@ -49,6 +53,8 @@ jobs:
 
   release-main:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     # XXX disable main builds until we have a valid token
     # if: github.ref == 'refs/heads/main'
     if: false
@@ -57,6 +63,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Tool versions
         uses: wistia/parse-tool-versions@32f568a4ffd4bfa7720ebf93f171597d1ebc979a # v2.1.1
@@ -67,6 +74,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GOLANG_TOOL_VERSION }}
+          cache: false
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/rhysd/actionlint
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca  # frozen: v1.7.12
+    hooks:
+      - id: actionlint
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: a4727cbbcd26d7098e96b9cb738169b59711ae51  # frozen: v1.24.1
+    hooks:
+      - id: zizmor
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: 2ccb47ff45ad361a21071a7eedda4c37e6ae8c5a  # frozen: v2.4.2
+    hooks:
+      - id: codespell
+
+  - repo: https://github.com/crate-ci/typos
+    rev: cf5f1c29a8ac336af8568821ec41919923b05a83  # frozen: v1.45.1
+    hooks:
+      - id: typos
+

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,5 @@
 golang        1.25
 golangci-lint v2.8.0
 just          1.50.0
+uv            0.8.14
+

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,6 @@
+[files]
+extend-exclude = [ "internal/acceptance_tests/recordings/*.json", ".pre-commit-config.yaml" ]
+
+[default.extend-words]
+# Hashicorp think they're hilarious
+"copywrite" = "copywrite"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   - `stacklet_sso_group`
 - Fix: remove unused fields in `stacklet_user` datasource
 - Fix: graphql query errors in `stacklet_role_assignment` resource (#205)
-- Chore: udpate dependnecies
+- Chore: update dependencies
 
 
 ## 0.6.3 - 2026-04-22

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ resource "stacklet_policy_collection_mapping" "one" {
 resource "stacklet_account" "two" {
   cloud_provider = "AWS"
   key            = "000000000000" # AWS account ID
-  name           = "test-acccount"
+  name           = "test-account"
   short_name     = "tftest"
   description    = "Test account"
   email          = "cloud-team@example.com"
@@ -198,6 +198,6 @@ from terraform.  To enable debug:
 2. Create a release tag with `just tag-release X.Y.Z <ref>` on the desired
    commit (default `HEAD`).
 3. Push the tag upstream. This will start the Release workflow which creates
-   the release on GitHub and builds packages.  Once it completes, the relase
+   the release on GitHub and builds packages.  Once it completes, the release
    will be published and the Terraform registry will pick up the new release
    automatically.

--- a/internal/api/binding.go
+++ b/internal/api/binding.go
@@ -69,7 +69,7 @@ type BindingExecutionConfig struct {
 	Variables       *string                                `json:"variables"`
 }
 
-// BindingExecutionConfigDryRun holds the dry run confiuration for a binding execution config.
+// BindingExecutionConfigDryRun holds the dry run configuration for a binding execution config.
 type BindingExecutionConfigDryRun struct {
 	Default bool `json:"default"`
 }

--- a/internal/api/configuration_profile.go
+++ b/internal/api/configuration_profile.go
@@ -171,7 +171,7 @@ func (i msteamsConfigurationInput) GetGraphQLType() string {
 	return "MSTeamsConfigurationInput"
 }
 
-// JiraConfiguation is the configuration for Jira profiles.
+// JiraConfiguration is the configuration for Jira profiles.
 type JiraConfiguration struct {
 	URL      *string       `graphql:"url" json:"url"`
 	Projects []JiraProject `json:"projects"`
@@ -179,7 +179,7 @@ type JiraConfiguration struct {
 	APIKey   string        `json:"apiKey"`
 }
 
-// JiraPorject is the configuration for a Jira project.
+// JiraProject is the configuration for a Jira project.
 type JiraProject struct {
 	ClosedStatus string `json:"closedStatus"`
 	IssueType    string `json:"issueType"`
@@ -198,7 +198,7 @@ func (i jiraConfigurationInput) GetGraphQLType() string {
 	return "JiraConfigurationInput"
 }
 
-// ResourceOwnerConfiguration is the configuation for resource owner.
+// ResourceOwnerConfiguration is the configuration for resource owner.
 type ResourceOwnerConfiguration struct {
 	// "default" is present with different type in both resource and account, so it must be aliased
 	Default      []string `graphql:"resourceOwnerDefault: default" json:"default"`
@@ -560,7 +560,7 @@ func (a configurationProfileAPI) UpsertMSTeams(ctx context.Context, input MSTeam
 	return &mutation.Payload.Configuration, nil
 }
 
-// Delete removes a configuation profile.
+// Delete removes a configuration profile.
 func (a configurationProfileAPI) Delete(ctx context.Context, name ConfigurationProfileName) error {
 	var mutation struct {
 		ID graphql.ID `graphql:"removeProfile(scope: $scope, name: $name)"`

--- a/internal/models/account.go
+++ b/internal/models/account.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stacklet/terraform-provider-stacklet/internal/typehelpers"
 )
 
-// AcountDataSource is the model for account data sources.
+// AccountDataSource is the model for account data sources.
 type AccountDataSource struct {
 	ID              types.String `tfsdk:"id"`
 	Key             types.String `tfsdk:"key"`

--- a/internal/schemadefault/empty.go
+++ b/internal/schemadefault/empty.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// EmtpyListDefault returns an empty default for a resource field.
+// EmptyListDefault returns an empty default for a resource field.
 func EmptyListDefault(attrType attr.Type) defaults.List {
 	return listdefault.StaticValue(types.ListValueMust(attrType, []attr.Value{}))
 }

--- a/justfile
+++ b/justfile
@@ -16,7 +16,11 @@ format-go:
     go fmt ./...
 
 # Run linters
-lint: lint-go lint-tf lint-docs lint-copyright
+lint: lint-go lint-tf lint-docs lint-copyright lint-pre-commit
+
+# Run pre-commit linters
+lint-pre-commit:
+    uvx prek run --all-files
 
 # Run linters for terraform
 lint-tf:


### PR DESCRIPTION
### what

- Add `.pre-commit-config.yaml` with actionlint, zizmor, codespell,
  and typos hooks
- Add `.typos.toml` config excluding recording fixtures and allowing
  Hashicorp's intentional "copywrite" spelling
- Add `.github/actionlint.yaml` to suppress a false-positive
  `constant expression "false" in condition` in `release.yaml`
- Add `lint-pre-commit` recipe to `justfile` (`uvx prek run
  --all-files`) and include it in the top-level `lint` target
- Add `lint-pre-commit` job to CI workflow
- Add `persist-credentials: false` to every `actions/checkout` step
  across `ci.yaml` and `release.yaml`
- Scope `contents: write` permission from workflow level down to the
  two release jobs in `release.yaml`
- Disable Go module cache (`cache: false`) in `setup-go` steps in
  `release.yaml`
- Consolidate two separate `gomod` dependabot entries into one with
  `directories`, switch both ecosystems to monthly schedule with 7-day
  cooldown and grouped updates
- Fix typos throughout: comments, type names, and prose in
  `CHANGELOG.md`, `README.md`, `internal/api/binding.go`,
  `internal/api/configuration_profile.go`,
  `internal/models/account.go`, and `internal/schemadefault/empty.go`

### why

The typos tool (now running in pre-commit and CI) caught several
misspellings in comments and type names. Adding zizmor identified the
CI permission issues: `contents: write` at workflow scope is broader
than necessary, and not setting `persist-credentials: false` leaves
the default GitHub token credential in the checkout longer than needed.
Pre-commit provides a local fast-feedback loop matching what CI checks.

### testing

All existing acceptance tests continue to pass in replay mode
(`just test`). The new `lint-pre-commit` job runs `pre-commit` across
all files in CI.

### docs

No docs needed.

---------------------------

🤖 Generated with [Claude Code](https://claude.com/claude-code)