### PR TITLE
chore: add resource/datasource schema helpers for TerraformModule

### DIFF
--- a/docs/data-sources/platform.md
+++ b/docs/data-sources/platform.md
@@ -33,20 +33,17 @@ data "stacklet_platform" "example" {}
 
 Read-Only:
 
-- `terraform_module` (Attributes) Terraform module configuration for account setup. (see [below for nested schema](#nestedatt--aws_account_customer_config--terraform_module))
+- `terraform_module` (Attributes) Terraform module configuration. (see [below for nested schema](#nestedatt--aws_account_customer_config--terraform_module))
 
 <a id="nestedatt--aws_account_customer_config--terraform_module"></a>
 ### Nested Schema for `aws_account_customer_config.terraform_module`
 
-Optional:
-
-- `version` (String) Module version.
-
 Read-Only:
 
-- `repository_url` (String) Module repository URL.
-- `source` (String) Module source.
-- `variables_json` (String) JSON-encoded variables for module configuration.
+- `repository_url` (String) The repository URL.
+- `source` (String) The module source.
+- `variables_json` (String) The module variables as JSON.
+- `version` (String) The module version.
 
 
 
@@ -55,17 +52,14 @@ Read-Only:
 
 Read-Only:
 
-- `terraform_module` (Attributes) Terraform module configuration for organization read access setup. (see [below for nested schema](#nestedatt--aws_org_read_customer_config--terraform_module))
+- `terraform_module` (Attributes) Terraform module configuration. (see [below for nested schema](#nestedatt--aws_org_read_customer_config--terraform_module))
 
 <a id="nestedatt--aws_org_read_customer_config--terraform_module"></a>
 ### Nested Schema for `aws_org_read_customer_config.terraform_module`
 
-Optional:
-
-- `version` (String) Module version.
-
 Read-Only:
 
-- `repository_url` (String) Module repository URL.
-- `source` (String) Module source.
-- `variables_json` (String) JSON-encoded variables for module configuration.
+- `repository_url` (String) The repository URL.
+- `source` (String) The module source.
+- `variables_json` (String) The module variables as JSON.
+- `version` (String) The module version.

--- a/internal/datasources/configuration_profile_msteams.go
+++ b/internal/datasources/configuration_profile_msteams.go
@@ -104,28 +104,7 @@ func (d *configurationProfileMSTeamsDataSource) Schema(_ context.Context, _ data
 						ElementType: types.StringType,
 						Computed:    true,
 					},
-					"terraform_module": schema.SingleNestedAttribute{
-						Description: "Terraform module configuration.",
-						Computed:    true,
-						Attributes: map[string]schema.Attribute{
-							"repository_url": schema.StringAttribute{
-								Description: "The repository URL.",
-								Computed:    true,
-							},
-							"source": schema.StringAttribute{
-								Description: "The module source.",
-								Computed:    true,
-							},
-							"version": schema.StringAttribute{
-								Description: "The module version.",
-								Computed:    true,
-							},
-							"variables_json": schema.StringAttribute{
-								Description: "The module variables as JSON.",
-								Computed:    true,
-							},
-						},
-					},
+					"terraform_module": models.TerraformModule{}.DataSourceSchemaAttribute(),
 				},
 			},
 			"entity_details": schema.SingleNestedAttribute{

--- a/internal/datasources/gcp_integration.go
+++ b/internal/datasources/gcp_integration.go
@@ -30,25 +30,6 @@ func (d *gcpIntegrationDataSource) Metadata(_ context.Context, req datasource.Me
 }
 
 func (d *gcpIntegrationDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	terraformModuleAttrs := map[string]schema.Attribute{
-		"repository_url": schema.StringAttribute{
-			Description: "The Terraform module repository URL.",
-			Computed:    true,
-		},
-		"source": schema.StringAttribute{
-			Description: "The Terraform module source.",
-			Computed:    true,
-		},
-		"version": schema.StringAttribute{
-			Description: "The Terraform module version.",
-			Computed:    true,
-		},
-		"variables_json": schema.StringAttribute{
-			Description: "The Terraform module variables as JSON.",
-			Computed:    true,
-		},
-	}
-
 	resp.Schema = schema.Schema{
 		Description: "Retrieve information about a GCP integration.",
 		Attributes: map[string]schema.Attribute{
@@ -96,19 +77,10 @@ func (d *gcpIntegrationDataSource) Schema(_ context.Context, _ datasource.Schema
 										Description: "The folder in which to create the project.",
 										Computed:    true,
 									},
-									"labels": schema.ListNestedAttribute{
+									"labels": schema.MapAttribute{
 										Description: "Labels applied to the created project.",
-										Computed:    true,
-										NestedObject: schema.NestedAttributeObject{
-											Attributes: map[string]schema.Attribute{
-												"key": schema.StringAttribute{
-													Computed: true,
-												},
-												"value": schema.StringAttribute{
-													Computed: true,
-												},
-											},
-										},
+										Optional:    true,
+										ElementType: types.StringType,
 									},
 								},
 							},
@@ -165,11 +137,7 @@ func (d *gcpIntegrationDataSource) Schema(_ context.Context, _ datasource.Schema
 							},
 						},
 					},
-					"terraform_module": schema.SingleNestedAttribute{
-						Description: "Terraform module to deploy this integration, computed by Stacklet.",
-						Computed:    true,
-						Attributes:  terraformModuleAttrs,
-					},
+					"terraform_module": models.TerraformModule{}.DataSourceSchemaAttribute(),
 				},
 			},
 			"access_config": schema.SingleNestedAttribute{

--- a/internal/datasources/platform.go
+++ b/internal/datasources/platform.go
@@ -50,58 +50,14 @@ func (d *platformDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 				Description: "Customer configuration for AWS accounts.",
 				Computed:    true,
 				Attributes: map[string]schema.Attribute{
-					"terraform_module": schema.SingleNestedAttribute{
-						Description: "Terraform module configuration for account setup.",
-						Computed:    true,
-						Attributes: map[string]schema.Attribute{
-							"repository_url": schema.StringAttribute{
-								Description: "Module repository URL.",
-								Computed:    true,
-							},
-							"source": schema.StringAttribute{
-								Description: "Module source.",
-								Computed:    true,
-							},
-							"variables_json": schema.StringAttribute{
-								Description: "JSON-encoded variables for module configuration.",
-								Computed:    true,
-							},
-							"version": schema.StringAttribute{
-								Description: "Module version.",
-								Computed:    true,
-								Optional:    true,
-							},
-						},
-					},
+					"terraform_module": models.TerraformModule{}.DataSourceSchemaAttribute(),
 				},
 			},
 			"aws_org_read_customer_config": schema.SingleNestedAttribute{
 				Description: "Customer configuration for AWS organization read access.",
 				Computed:    true,
 				Attributes: map[string]schema.Attribute{
-					"terraform_module": schema.SingleNestedAttribute{
-						Description: "Terraform module configuration for organization read access setup.",
-						Computed:    true,
-						Attributes: map[string]schema.Attribute{
-							"repository_url": schema.StringAttribute{
-								Description: "Module repository URL.",
-								Computed:    true,
-							},
-							"source": schema.StringAttribute{
-								Description: "Module source.",
-								Computed:    true,
-							},
-							"variables_json": schema.StringAttribute{
-								Description: "JSON-encoded variables for module configuration.",
-								Computed:    true,
-							},
-							"version": schema.StringAttribute{
-								Description: "Module version.",
-								Computed:    true,
-								Optional:    true,
-							},
-						},
-					},
+					"terraform_module": models.TerraformModule{}.DataSourceSchemaAttribute(),
 				},
 			},
 		},

--- a/internal/models/common.go
+++ b/internal/models/common.go
@@ -4,6 +4,8 @@ package models
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	dsSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	resSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -24,15 +26,52 @@ func (c TerraformModule) AttributeTypes() map[string]attr.Type {
 	}
 }
 
-// Tag is the model for tags.
-type Tag struct {
-	Key   types.String `tfsdk:"key"`
-	Value types.String `tfsdk:"value"`
+func (c TerraformModule) ResourceSchemaAttribute() resSchema.SingleNestedAttribute {
+	return resSchema.SingleNestedAttribute{
+		Description: "Terraform module configuration.",
+		Computed:    true,
+		Attributes: map[string]resSchema.Attribute{
+			"repository_url": resSchema.StringAttribute{
+				Description: "The repository URL.",
+				Computed:    true,
+			},
+			"source": resSchema.StringAttribute{
+				Description: "The module source.",
+				Computed:    true,
+			},
+			"version": resSchema.StringAttribute{
+				Description: "The module version.",
+				Computed:    true,
+			},
+			"variables_json": resSchema.StringAttribute{
+				Description: "The module variables as JSON.",
+				Computed:    true,
+			},
+		},
+	}
 }
 
-func (t Tag) AttributeTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"key":   types.StringType,
-		"value": types.StringType,
+func (c TerraformModule) DataSourceSchemaAttribute() dsSchema.SingleNestedAttribute {
+	return dsSchema.SingleNestedAttribute{
+		Description: "Terraform module configuration.",
+		Computed:    true,
+		Attributes: map[string]dsSchema.Attribute{
+			"repository_url": dsSchema.StringAttribute{
+				Description: "The repository URL.",
+				Computed:    true,
+			},
+			"source": dsSchema.StringAttribute{
+				Description: "The module source.",
+				Computed:    true,
+			},
+			"version": dsSchema.StringAttribute{
+				Description: "The module version.",
+				Computed:    true,
+			},
+			"variables_json": dsSchema.StringAttribute{
+				Description: "The module variables as JSON.",
+				Computed:    true,
+			},
+		},
 	}
 }

--- a/internal/models/gcp_integration.go
+++ b/internal/models/gcp_integration.go
@@ -140,15 +140,7 @@ func (m GCPIntegrationDataSource) buildCustomerCreateProject(cp *api.GCPIntegrat
 		return nullObj, diags
 	}
 
-	labels, d := typehelpers.ObjectList[Tag](
-		cp.Labels,
-		func(t api.Tag) (map[string]attr.Value, diag.Diagnostics) {
-			return map[string]attr.Value{
-				"key":   types.StringValue(t.Key),
-				"value": types.StringValue(t.Value),
-			}, nil
-		},
-	)
+	labels, d := api.TagsList(cp.Labels).TagsMap()
 	diags.Append(d...)
 	if diags.HasError() {
 		return nullObj, diags
@@ -372,7 +364,7 @@ type GCPIntegrationCustomerCreateProjectModel struct {
 	BillingAccountID types.String `tfsdk:"billing_account_id"`
 	OrgID            types.String `tfsdk:"org_id"`
 	FolderID         types.String `tfsdk:"folder_id"`
-	Labels           types.List   `tfsdk:"labels"`
+	Labels           types.Map    `tfsdk:"labels"`
 }
 
 func (m GCPIntegrationCustomerCreateProjectModel) AttributeTypes() map[string]attr.Type {
@@ -380,7 +372,7 @@ func (m GCPIntegrationCustomerCreateProjectModel) AttributeTypes() map[string]at
 		"billing_account_id": types.StringType,
 		"org_id":             types.StringType,
 		"folder_id":          types.StringType,
-		"labels":             types.ListType{ElemType: types.ObjectType{AttrTypes: Tag{}.AttributeTypes()}},
+		"labels":             types.MapType{ElemType: types.StringType},
 	}
 }
 

--- a/internal/resources/configuration_profile_msteams.go
+++ b/internal/resources/configuration_profile_msteams.go
@@ -149,28 +149,7 @@ The profile is global, adding multiple resources of this kind will cause them to
 						ElementType: types.StringType,
 						Computed:    true,
 					},
-					"terraform_module": schema.SingleNestedAttribute{
-						Description: "Terraform module configuration.",
-						Computed:    true,
-						Attributes: map[string]schema.Attribute{
-							"repository_url": schema.StringAttribute{
-								Description: "The repository URL.",
-								Computed:    true,
-							},
-							"source": schema.StringAttribute{
-								Description: "The module source.",
-								Computed:    true,
-							},
-							"version": schema.StringAttribute{
-								Description: "The module version.",
-								Computed:    true,
-							},
-							"variables_json": schema.StringAttribute{
-								Description: "The module variables as JSON.",
-								Computed:    true,
-							},
-						},
-					},
+					"terraform_module": models.TerraformModule{}.ResourceSchemaAttribute(),
 				},
 			},
 			"customer_config_input": schema.SingleNestedAttribute{


### PR DESCRIPTION
### what

add helpers to return the schema for resource and datasource attributes for TerraformModule, remove the Tag helper and use a map instead

### why

avoid repetition in schema

### testing

tests pass

### docs

regenerated
