### PR TITLE
chore: handle parsing all env vars in one place

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/stacklet/terraform-provider-stacklet
 go 1.25.8
 
 require (
+	github.com/caarlos0/env/v11 v11.4.1
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
+github.com/caarlos0/env/v11 v11.4.1 h1:fYwH0sWEsBSMPG7t4e/PEfTFzrWrpjyygXyUnWiSwEw=
+github.com/caarlos0/env/v11 v11.4.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=

--- a/internal/datasources/datasources.go
+++ b/internal/datasources/datasources.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 )
 
-// DataSources returns all available datasources..
+// DataSources returns all available datasources.
 func DataSources(includeUnreleased bool) []func() datasource.DataSource {
 	dataSources := []func() datasource.DataSource{
 		newAccountDataSource,

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -34,7 +34,7 @@ func AsDiagError(err error) DiagError {
 	if ok {
 		return e
 	}
-	return diagError{err: e}
+	return diagError{err: err}
 }
 
 // AddDiagError adds an error to the diagnostics.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,18 +7,19 @@ import (
 	"encoding/json"
 	"os"
 	"path"
-	"strconv"
 
+	"github.com/caarlos0/env/v11"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	tfpath "github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/stacklet/terraform-provider-stacklet/internal/api"
 	"github.com/stacklet/terraform-provider-stacklet/internal/datasources"
+	"github.com/stacklet/terraform-provider-stacklet/internal/errors"
 	"github.com/stacklet/terraform-provider-stacklet/internal/providerdata"
 	"github.com/stacklet/terraform-provider-stacklet/internal/resources"
 )
@@ -27,19 +28,18 @@ var (
 	_ provider.Provider = &stackletProvider{}
 )
 
-type stackletProviderModel struct {
+// providerModel holds the terraform configuration for the provider.
+type providerModel struct {
 	Endpoint types.String `tfsdk:"endpoint"`
 	APIKey   types.String `tfsdk:"api_key"`
 }
 
-func New(version string) func() provider.Provider {
-	return func() provider.Provider {
-		return &stackletProvider{
-			version:           version,
-			includeUnreleased: os.Getenv("STACKLET_UNRELEASED_FEATURES") != "",
-			apiPageSize:       getEnvInt("STACKLET_PAGE_SIZE", 100),
-		}
-	}
+// providerEnv holds environment variables supported by the provider.
+type providerEnv struct {
+	Endpoint           string `env:"STACKLET_ENDPOINT"`
+	APIKey             string `env:"STACKLET_API_KEY"`
+	PageSize           int    `env:"STACKLET_PAGE_SIZE" envDefault:"100"`
+	UnreleasedFeatures bool   `env:"STACKLET_UNRELEASED_FEATURES"`
 }
 
 type stackletProvider struct {
@@ -47,12 +47,14 @@ type stackletProvider struct {
 	// provider is built and run locally, and "test" when running acceptance
 	// testing.
 	version string
+}
 
-	// whether to include unreleased resources/datasources
-	includeUnreleased bool
-
-	// page size for paginated
-	apiPageSize int
+func New(version string) func() provider.Provider {
+	return func() provider.Provider {
+		return &stackletProvider{
+			version: version,
+		}
+	}
 }
 
 // Metadata returns the provider type name.
@@ -70,14 +72,6 @@ This provider interacts with Stacklet's cloud governance platform.
 It allows managing resources like accounts, account groups, policy collections, bindings and so on.
 `,
 		Attributes: map[string]schema.Attribute{
-			"endpoint": schema.StringAttribute{
-				Description: `
-The endpoint URL of the Stacklet GraphQL API.
-
- May also be provided via STACKLET_ENDPOINT environment variable, or from the stacklet-admin CLI configuration.
-`,
-				Optional: true,
-			},
 			"api_key": schema.StringAttribute{
 				Description: `
 The API key for Stacklet authentication.
@@ -87,60 +81,35 @@ May also be provided via STACKLET_API_KEY environment variable, or from the stac
 				Optional:  true,
 				Sensitive: true,
 			},
+			"endpoint": schema.StringAttribute{
+				Description: `
+The endpoint URL of the Stacklet GraphQL API.
+
+ May also be provided via STACKLET_ENDPOINT environment variable, or from the stacklet-admin CLI configuration.
+`,
+				Optional: true,
+			},
 		},
 	}
 }
 
 // Configure prepares a Stacklet API client for data sources and resources.
 func (p *stackletProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
-	tflog.Info(ctx, "Configuring Stacklet client")
-
-	var config stackletProviderModel
+	var config providerModel
 	diags := req.Config.Get(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// If practitioner provided a configuration value for any of the
-	// attributes, it must be a known value.
-	if config.Endpoint.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			tfpath.Root("endpoint"),
-			"Unknown Stacklet API Endpoint",
-			"The provider cannot create the Stacklet API client as there is an unknown configuration value for the Stacklet API endpoint. "+
-				"Either target apply the source of the value first, set the value statically in the configuration, or use the STACKLET_ENDPOINT environment variable.",
-		)
-	}
-	if config.APIKey.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			tfpath.Root("api_key"),
-			"Unknown Stacklet API Key",
-			"The provider cannot create the Stacklet API client as there is an unknown configuration value for the Stacklet API key. "+
-				"Either target apply the source of the value first, set the value statically in the configuration, or use the STACKLET_API_KEY environment variable.",
-		)
-	}
-	if resp.Diagnostics.HasError() {
+	env, err := envConfig()
+	if err != nil {
+		errors.AddDiagError(&resp.Diagnostics, err)
 		return
 	}
 
-	creds := getCredentials(config)
-	if creds.Endpoint == "" {
-		resp.Diagnostics.AddAttributeError(
-			tfpath.Root("endpoint"),
-			"Missing Stacklet API Endpoint",
-			"The provider cannot create the Stacklet API client as there is a missing or empty value for the Stacklet API endpoint. "+
-				"Set the endpoint value in the configuration, in the STACKLET_ENDPOINT environment variable, or login via the stacklet-admin CLI first.",
-		)
-	}
-	if creds.APIKey == "" {
-		resp.Diagnostics.AddAttributeError(
-			tfpath.Root("api_key"),
-			"Missing Stacklet API Key",
-			"The provider cannot create the Stacklet API client as there is a missing or empty value for the Stacklet API key. "+
-				"Set the api_key value in the configuration, in the STACKLET_API_KEY environment variable, or login via the stacklet-admin CLI first.",
-		)
-	}
+	creds, diags := getCredentials(config, env)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -152,23 +121,27 @@ func (p *stackletProvider) Configure(ctx context.Context, req provider.Configure
 			Endpoint: creds.Endpoint,
 			APIKey:   creds.APIKey,
 			Version:  p.version,
-			PageSize: p.apiPageSize,
+			PageSize: env.PageSize,
 		},
 	)
 	resp.ResourceData = providerData
 	resp.DataSourceData = providerData
-
-	tflog.Info(ctx, "Configured Stacklet client")
 }
 
 // DataSources defines the data sources implemented in the provider.
 func (p *stackletProvider) DataSources(_ context.Context) []func() datasource.DataSource {
-	return datasources.DataSources(p.includeUnreleased)
+	conf, _ := envConfig()
+	return datasources.DataSources(conf.UnreleasedFeatures)
 }
 
 // Resources defines the resources implemented in the provider.
 func (p *stackletProvider) Resources(_ context.Context) []func() resource.Resource {
-	return resources.Resources(p.includeUnreleased)
+	conf, _ := envConfig()
+	return resources.Resources(conf.UnreleasedFeatures)
+}
+
+func envConfig() (providerEnv, error) {
+	return env.ParseAs[providerEnv]()
 }
 
 type credentials struct {
@@ -176,8 +149,29 @@ type credentials struct {
 	APIKey   string
 }
 
-func getCredentials(config stackletProviderModel) *credentials {
-	creds := credentials{}
+func getCredentials(config providerModel, env providerEnv) (credentials, diag.Diagnostics) {
+	var creds credentials
+	var diags diag.Diagnostics
+
+	if config.Endpoint.IsUnknown() {
+		diags.AddAttributeError(
+			tfpath.Root("endpoint"),
+			"Unknown Stacklet API Endpoint",
+			"The provider cannot create the Stacklet API client as there is an unknown configuration value for the Stacklet API endpoint. "+
+				"Either target apply the source of the value first, set the value statically in the configuration, or use the STACKLET_ENDPOINT environment variable.",
+		)
+	}
+	if config.APIKey.IsUnknown() {
+		diags.AddAttributeError(
+			tfpath.Root("api_key"),
+			"Unknown Stacklet API key",
+			"The provider cannot create the Stacklet API client as there is an unknown configuration value for the Stacklet API key. "+
+				"Either target apply the source of the value first, set the value statically in the configuration, or use the STACKLET_API_KEY environment variable.",
+		)
+	}
+	if diags.HasError() {
+		return creds, diags
+	}
 
 	// lookup provider configuration (might return empty strings)
 	creds.Endpoint = config.Endpoint.ValueString()
@@ -185,15 +179,14 @@ func getCredentials(config stackletProviderModel) *credentials {
 
 	// lookup environment variables
 	if creds.Endpoint == "" {
-		creds.Endpoint = os.Getenv("STACKLET_ENDPOINT")
+		creds.Endpoint = env.Endpoint
 	}
 	if creds.APIKey == "" {
-		creds.APIKey = os.Getenv("STACKLET_API_KEY")
+		creds.APIKey = env.APIKey
 	}
 
 	// lookup stacklet-admin configuration
 	if homeDir, err := os.UserHomeDir(); err == nil {
-
 		if creds.Endpoint == "" {
 			configFile := path.Join(homeDir, ".stacklet", "config.json")
 			if content, err := os.ReadFile(configFile); err == nil {
@@ -214,15 +207,21 @@ func getCredentials(config stackletProviderModel) *credentials {
 		}
 	}
 
-	return &creds
-}
-
-// getEnvInt returns an integer from an environment variable, fallback if unset
-// or invalid.
-func getEnvInt(name string, fallback int) int {
-	value, err := strconv.Atoi(os.Getenv(name))
-	if err == nil {
-		return value
+	if creds.Endpoint == "" {
+		diags.AddAttributeError(
+			tfpath.Root("endpoint"),
+			"Missing Stacklet API Endpoint",
+			"The provider cannot create the Stacklet API client as there is a missing or empty value for the Stacklet API endpoint. "+
+				"Set the endpoint value in the configuration, in the STACKLET_ENDPOINT environment variable, or login via the stacklet-admin CLI first.",
+		)
 	}
-	return fallback
+	if creds.APIKey == "" {
+		diags.AddAttributeError(
+			tfpath.Root("api_key"),
+			"Missing Stacklet API key",
+			"The provider cannot create the Stacklet API client as there is a missing or empty value for the Stacklet API key. "+
+				"Set the api_key value in the configuration, in the STACKLET_API_KEY environment variable, or login via the stacklet-admin CLI first.",
+		)
+	}
+	return creds, diags
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func setHomeDir(t *testing.T) string {
@@ -28,7 +29,7 @@ func makeStackletAdminDir(t *testing.T) string {
 	return stackletDir
 }
 
-func setupStackletAdminConfig(t *testing.T, endpoint, apiKey string) {
+func setupStackletAdminConfig(t *testing.T, endpoint string, apiKey string) {
 	stackletDir := makeStackletAdminDir(t)
 
 	if endpoint != "" {
@@ -48,163 +49,162 @@ func setupStackletAdminConfig(t *testing.T, endpoint, apiKey string) {
 	}
 }
 
-func TestGetCredentials_FromConfig(t *testing.T) {
-	config := stackletProviderModel{
+func TestGetCredentials(t *testing.T) {
+	envFull := providerEnv{
+		Endpoint: "https://env-endpoint.example.com",
+		APIKey:   "env-api-key",
+	}
+	configFull := providerModel{
 		Endpoint: types.StringValue("https://config-endpoint.example.com"),
 		APIKey:   types.StringValue("config-api-key"),
 	}
-
-	creds := getCredentials(config)
-	assert.Equal(t, "https://config-endpoint.example.com", creds.Endpoint)
-	assert.Equal(t, "config-api-key", creds.APIKey)
-}
-
-func TestGetCredentials_FromEnvVars(t *testing.T) {
-	t.Setenv("STACKLET_ENDPOINT", "https://env-endpoint.example.com")
-	t.Setenv("STACKLET_API_KEY", "env-api-key")
-
-	config := stackletProviderModel{
-		Endpoint: types.StringNull(),
-		APIKey:   types.StringNull(),
+	adminCLIFull := &credentials{
+		Endpoint: "https://cli-endpoint.example.com",
+		APIKey:   "cli-api-key",
 	}
 
-	creds := getCredentials(config)
-	assert.Equal(t, "https://env-endpoint.example.com", creds.Endpoint)
-	assert.Equal(t, "env-api-key", creds.APIKey)
-}
-
-func TestGetCredentials_ConfigOverridesEnvVars(t *testing.T) {
-	t.Setenv("STACKLET_ENDPOINT", "https://env-endpoint.example.com")
-	t.Setenv("STACKLET_API_KEY", "env-api-key")
-
-	config := stackletProviderModel{
-		Endpoint: types.StringValue("https://config-endpoint.example.com"),
-		APIKey:   types.StringValue("config-api-key"),
+	tests := []struct {
+		name       string
+		env        providerEnv
+		config     providerModel
+		adminCLI   *credentials
+		expected   credentials
+		diagErrors []string
+	}{
+		{
+			name:   "FromConfig",
+			config: configFull,
+			expected: credentials{
+				Endpoint: "https://config-endpoint.example.com",
+				APIKey:   "config-api-key",
+			},
+		},
+		{
+			name: "FromEnviron",
+			env:  envFull,
+			expected: credentials{
+				Endpoint: "https://env-endpoint.example.com",
+				APIKey:   "env-api-key",
+			},
+		},
+		{
+			name:     "FromAdminCLI",
+			adminCLI: adminCLIFull,
+			expected: credentials{
+				Endpoint: "https://cli-endpoint.example.com",
+				APIKey:   "cli-api-key",
+			},
+		},
+		{
+			name:   "ConfigOverridesEnviron",
+			env:    envFull,
+			config: configFull,
+			expected: credentials{
+				Endpoint: "https://config-endpoint.example.com",
+				APIKey:   "config-api-key",
+			},
+		},
+		{
+			name:     "EnvironOverridesAdminCLI",
+			env:      envFull,
+			adminCLI: adminCLIFull,
+			expected: credentials{
+				Endpoint: "https://env-endpoint.example.com",
+				APIKey:   "env-api-key",
+			},
+		},
+		{
+			name: "MixedSources",
+			env: providerEnv{
+				APIKey: "env-api-key",
+			},
+			adminCLI: &credentials{
+				Endpoint: "https://cli-endpoint.example.com",
+			},
+			expected: credentials{
+				Endpoint: "https://cli-endpoint.example.com",
+				APIKey:   "env-api-key",
+			},
+		},
+		{
+			name: "MissingEndpoint",
+			config: providerModel{
+				APIKey: types.StringValue("config-api-key"),
+			},
+			diagErrors: []string{"Missing Stacklet API Endpoint"},
+		},
+		{
+			name: "MissingAPIKey",
+			config: providerModel{
+				Endpoint: types.StringValue("https://config-endpoint.example.com"),
+			},
+			diagErrors: []string{"Missing Stacklet API key"},
+		},
+		{
+			name: "MissingBoth",
+			diagErrors: []string{
+				"Missing Stacklet API Endpoint",
+				"Missing Stacklet API key",
+			},
+		},
+		{
+			name: "UnknownEndpoint",
+			config: providerModel{
+				Endpoint: types.StringUnknown(),
+				APIKey:   types.StringValue("config-api-key"),
+			},
+			diagErrors: []string{"Unknown Stacklet API Endpoint"},
+		},
+		{
+			name: "UnknownAPIKey",
+			config: providerModel{
+				Endpoint: types.StringValue("https://config-endpoint.example.com"),
+				APIKey:   types.StringUnknown(),
+			},
+			diagErrors: []string{"Unknown Stacklet API key"},
+		},
+		{
+			name: "UnknownBoth",
+			config: providerModel{
+				Endpoint: types.StringUnknown(),
+				APIKey:   types.StringUnknown(),
+			},
+			diagErrors: []string{
+				"Unknown Stacklet API Endpoint",
+				"Unknown Stacklet API key",
+			},
+		},
 	}
 
-	creds := getCredentials(config)
-	assert.Equal(t, "https://config-endpoint.example.com", creds.Endpoint)
-	assert.Equal(t, "config-api-key", creds.APIKey)
-}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.adminCLI != nil {
+				setupStackletAdminConfig(t, tc.adminCLI.Endpoint, tc.adminCLI.APIKey)
+			} else {
+				setHomeDir(t)
+			}
 
-func TestGetCredentials_FromStackletAdminConfig(t *testing.T) {
-	setupStackletAdminConfig(t, "https://cli-endpoint.example.com", "cli-api-key")
-
-	config := stackletProviderModel{
-		Endpoint: types.StringNull(),
-		APIKey:   types.StringNull(),
+			creds, diags := getCredentials(tc.config, tc.env)
+			expectedErrors := len(tc.diagErrors)
+			if expectedErrors == 0 {
+				assert.Equal(t, tc.expected, creds)
+			}
+			require.Len(t, diags.Errors(), expectedErrors)
+			for i, msg := range tc.diagErrors {
+				assert.Contains(t, diags[i].Summary(), msg)
+			}
+		})
 	}
-
-	creds := getCredentials(config)
-	assert.Equal(t, "https://cli-endpoint.example.com", creds.Endpoint)
-	assert.Equal(t, "cli-api-key", creds.APIKey)
 }
 
-func TestGetCredentials_EnvVarsOverrideStackletAdminFiles(t *testing.T) {
-	t.Setenv("STACKLET_ENDPOINT", "https://env-endpoint.example.com")
-	t.Setenv("STACKLET_API_KEY", "env-api-key")
-
-	setupStackletAdminConfig(t, "https://cli-endpoint.example.com", "cli-api-key")
-
-	config := stackletProviderModel{
-		Endpoint: types.StringNull(),
-		APIKey:   types.StringNull(),
-	}
-
-	creds := getCredentials(config)
-	assert.Equal(t, "https://env-endpoint.example.com", creds.Endpoint)
-	assert.Equal(t, "env-api-key", creds.APIKey)
-}
-
-func TestGetCredentials_MixedSources(t *testing.T) {
-	t.Setenv("STACKLET_API_KEY", "env-api-key")
-
-	setupStackletAdminConfig(t, "https://cli-endpoint.example.com", "")
-
-	config := stackletProviderModel{
-		Endpoint: types.StringNull(),
-		APIKey:   types.StringNull(),
-	}
-
-	creds := getCredentials(config)
-	assert.Equal(t, "https://cli-endpoint.example.com", creds.Endpoint)
-	assert.Equal(t, "env-api-key", creds.APIKey)
-}
-
-func TestGetCredentials_Empty(t *testing.T) {
-	setupStackletAdminConfig(t, "", "")
-
-	config := stackletProviderModel{
-		Endpoint: types.StringNull(),
-		APIKey:   types.StringNull(),
-	}
-
-	creds := getCredentials(config)
-
-	assert.Equal(t, "", creds.Endpoint)
-	assert.Equal(t, "", creds.APIKey)
-}
-
-func TestGetCredentials_PartialConfig(t *testing.T) {
-	t.Setenv("STACKLET_API_KEY", "env-api-key")
-
-	config := stackletProviderModel{
-		Endpoint: types.StringValue("https://config-endpoint.example.com"),
-		APIKey:   types.StringNull(),
-	}
-
-	creds := getCredentials(config)
-
-	assert.Equal(t, "https://config-endpoint.example.com", creds.Endpoint)
-	assert.Equal(t, "env-api-key", creds.APIKey)
-}
-
-func TestGetCredentials_InvalidStackletAdminConfigJSON(t *testing.T) {
+func TestGetCredentials_InvalidAdminCLIConfigJSON(t *testing.T) {
 	stackletDir := makeStackletAdminDir(t)
 	configFile := path.Join(stackletDir, "config.json")
 	if err := os.WriteFile(configFile, []byte("invalid json"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	config := stackletProviderModel{
-		Endpoint: types.StringNull(),
-		APIKey:   types.StringNull(),
-	}
-
-	creds := getCredentials(config)
-	assert.Equal(t, "", creds.Endpoint)
-	assert.Equal(t, "", creds.APIKey)
-}
-
-func TestGetCredentials_MissingStackletAdminFiles(t *testing.T) {
-	setupStackletAdminConfig(t, "", "")
-
-	config := stackletProviderModel{
-		Endpoint: types.StringNull(),
-		APIKey:   types.StringNull(),
-	}
-
-	creds := getCredentials(config)
-	assert.Equal(t, "", creds.Endpoint)
-	assert.Equal(t, "", creds.APIKey)
-}
-
-func TestGetEnvInt(t *testing.T) {
-	tests := []struct {
-		name     string
-		envValue string
-		fallback int
-		expected int
-	}{
-		{"valid", "10", 20, 10},
-		{"unset", "", 20, 20},
-		{"invalid", "not-an-int", 20, 20},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("FOO", tc.envValue)
-			assert.Equal(t, tc.expected, getEnvInt("FOO", tc.fallback))
-		})
-	}
+	_, diags := getCredentials(providerModel{}, providerEnv{})
+	require.True(t, diags.HasError())
+	assert.Contains(t, diags[0].Summary(), "Missing Stacklet API Endpoint")
 }


### PR DESCRIPTION
### what

- add type for holding parsed values for environment variables
- rework getCredentials to use that and improve/consolidate tests

### why

general cleanups

### testing

updated tests

### docs

n/a
