### PR TITLE
chore: add graphql tags to structs

### DIFF
--- a/internal/api/account.go
+++ b/internal/api/account.go
@@ -10,17 +10,17 @@ import (
 
 // Account is the data returned by reading account data.
 type Account struct {
-	ID              graphql.ID
-	Key             string
-	Name            string
-	ShortName       *string
-	Description     *string
-	Provider        CloudProvider
-	Path            *string
-	Email           *string
-	Active          bool
-	SecurityContext *string
-	Variables       *string
+	ID              graphql.ID    `graphql:"id"`
+	Key             string        `graphql:"key"`
+	Name            string        `graphql:"name"`
+	ShortName       *string       `graphql:"shortName"`
+	Description     *string       `graphql:"description"`
+	Provider        CloudProvider `graphql:"provider"`
+	Path            *string       `graphql:"path"`
+	Email           *string       `graphql:"email"`
+	Active          bool          `graphql:"active"`
+	SecurityContext *string       `graphql:"securityContext"`
+	Variables       *string       `graphql:"variables"`
 }
 
 // AccountCreateInput is the input for creating an account.
@@ -114,8 +114,8 @@ func (a accountAPI) Delete(ctx context.Context, cloudProvider string, key string
 	var mutation struct {
 		Payload struct {
 			Account struct {
-				Key string
-			}
+				Key string `graphql:"key"`
+			} `graphql:"account"`
 		} `graphql:"removeAccount(provider: $provider, key: $key)"`
 	}
 	variables := map[string]any{

--- a/internal/api/account_discovery.go
+++ b/internal/api/account_discovery.go
@@ -10,41 +10,41 @@ import (
 
 // Account is the data returned by reading account data.
 type AccountDiscovery struct {
-	ID          graphql.ID
-	Name        string
-	Description *string
-	Provider    CloudProvider
+	ID          graphql.ID    `graphql:"id"`
+	Name        string        `graphql:"name"`
+	Description *string       `graphql:"description"`
+	Provider    CloudProvider `graphql:"provider"`
 	Config      struct {
 		TypeName    string                      `graphql:"__typename"`
 		AWSConfig   accountDiscoveryAWSConfig   `graphql:"... on AWSAccountDiscoveryConfig"`
 		AzureConfig accountDiscoveryAzureConfig `graphql:"... on AzureAccountDiscoveryConfig"`
 		GCPConfig   accountDiscoveryGCPConfig   `graphql:"... on GCPAccountDiscoveryConfig"`
-	}
+	} `graphql:"config"`
 	Schedule struct {
-		Suspended bool
-	}
+		Suspended bool `graphql:"suspended"`
+	} `graphql:"schedule"`
 }
 
 type accountDiscoveryAWSConfig struct {
-	OrgID         string
-	OrgRole       string
-	MemberRole    string
-	CustodianRole string
+	OrgID         string `graphql:"orgId"`
+	OrgRole       string `graphql:"orgRole"`
+	MemberRole    string `graphql:"memberRole"`
+	CustodianRole string `graphql:"custodianRole"`
 }
 
 type accountDiscoveryAzureConfig struct {
-	TenantID string
-	ClientID string
+	TenantID string `graphql:"tenantId"`
+	ClientID string `graphql:"clientId"`
 }
 
 type accountDiscoveryGCPConfig struct {
-	ClientEmail      string
-	ClientID         string
-	OrgID            string
-	RootFolderIDs    []string
-	ExcludeFolderIDs []string
-	ProjectID        string
-	PrivateKeyID     string
+	ClientEmail      string   `graphql:"clientEmail"`
+	ClientID         string   `graphql:"clientId"`
+	OrgID            string   `graphql:"orgId"`
+	RootFolderIDs    []string `graphql:"rootFolderIds"`
+	ExcludeFolderIDs []string `graphql:"excludeFolderIds"`
+	ProjectID        string   `graphql:"projectId"`
+	PrivateKeyID     string   `graphql:"privateKeyId"`
 }
 
 // AccountDiscoveryAWSInput is the input to create or update an AWS account discovery.

--- a/internal/api/account_discovery.go
+++ b/internal/api/account_discovery.go
@@ -26,25 +26,25 @@ type AccountDiscovery struct {
 }
 
 type accountDiscoveryAWSConfig struct {
-	OrgID         string `graphql:"orgID"`
-	OrgRole       string `graphql:"orgRole"`
-	MemberRole    string `graphql:"memberRole"`
-	CustodianRole string `graphql:"custodianRole"`
+	OrgID         string
+	OrgRole       string
+	MemberRole    string
+	CustodianRole string
 }
 
 type accountDiscoveryAzureConfig struct {
-	TenantID string `graphql:"tenantID"`
-	ClientID string `graphql:"clientID"`
+	TenantID string
+	ClientID string
 }
 
 type accountDiscoveryGCPConfig struct {
-	ClientEmail      string   `graphql:"clientEmail"`
-	ClientID         string   `graphql:"clientID"`
-	OrgID            string   `graphql:"orgID"`
-	RootFolderIDs    []string `graphql:"rootFolderIDs"`
-	ExcludeFolderIDs []string `graphql:"excludeFolderIDs"`
-	ProjectID        string   `graphql:"projectID"`
-	PrivateKeyID     string   `graphql:"privateKeyID"`
+	ClientEmail      string
+	ClientID         string
+	OrgID            string
+	RootFolderIDs    []string
+	ExcludeFolderIDs []string
+	ProjectID        string
+	PrivateKeyID     string
 }
 
 // AccountDiscoveryAWSInput is the input to create or update an AWS account discovery.

--- a/internal/api/account_group.go
+++ b/internal/api/account_group.go
@@ -10,14 +10,14 @@ import (
 
 // AccountGroup is the data returned by reading account group data.
 type AccountGroup struct {
-	ID                   graphql.ID
-	UUID                 string
-	Name                 string
-	Description          *string
-	DynamicFilter        *string
-	Provider             string
-	Regions              []string
-	RoleAssignmentTarget string
+	ID                   graphql.ID `graphql:"id"`
+	UUID                 string     `graphql:"uuid"`
+	Name                 string     `graphql:"name"`
+	Description          *string    `graphql:"description"`
+	DynamicFilter        *string    `graphql:"dynamicFilter"`
+	Provider             string     `graphql:"provider"`
+	Regions              []string   `graphql:"regions"`
+	RoleAssignmentTarget string     `graphql:"roleAssignmentTarget"`
 }
 
 // AccountGroupCreateInput is the input for creating an account group.

--- a/internal/api/binding.go
+++ b/internal/api/binding.go
@@ -10,20 +10,20 @@ import (
 
 // Binding is the data returned by reading binding details.
 type Binding struct {
-	ID           graphql.ID
-	UUID         string
-	Name         string
-	Description  *string
-	AutoDeploy   bool
-	Schedule     *string
+	ID           graphql.ID `graphql:"id"`
+	UUID         string     `graphql:"uuid"`
+	Name         string     `graphql:"name"`
+	Description  *string    `graphql:"description"`
+	AutoDeploy   bool       `graphql:"autoDeploy"`
+	Schedule     *string    `graphql:"schedule"`
 	AccountGroup struct {
-		UUID string
-	}
+		UUID string `graphql:"uuid"`
+	} `graphql:"accountGroup"`
 	PolicyCollection struct {
-		UUID string
-	}
-	ExecutionConfig BindingExecutionConfig
-	System          bool
+		UUID string `graphql:"uuid"`
+	} `graphql:"policyCollection"`
+	ExecutionConfig BindingExecutionConfig `graphql:"executionConfig"`
+	System          bool                   `graphql:"system"`
 }
 
 // DryRun returns the dryRun value for a binding execution config.
@@ -63,40 +63,40 @@ func (b Binding) PolicyResourceLimits() []BindingExecutionConfigResourceLimitsPo
 
 // ExecutionConfig holds the execution configuration for a binding.
 type BindingExecutionConfig struct {
-	DryRun          *BindingExecutionConfigDryRun          `json:"dryRun"`
-	ResourceLimits  *BindingExecutionConfigResourceLimits  `json:"resourceLimits"`
-	SecurityContext *BindingExecutionConfigSecurityContext `json:"securityContext"`
-	Variables       *string                                `json:"variables"`
+	DryRun          *BindingExecutionConfigDryRun          `graphql:"dryRun" json:"dryRun"`
+	ResourceLimits  *BindingExecutionConfigResourceLimits  `graphql:"resourceLimits" json:"resourceLimits"`
+	SecurityContext *BindingExecutionConfigSecurityContext `graphql:"securityContext" json:"securityContext"`
+	Variables       *string                                `graphql:"variables" json:"variables"`
 }
 
 // BindingExecutionConfigDryRun holds the dry run configuration for a binding execution config.
 type BindingExecutionConfigDryRun struct {
-	Default bool `json:"default"`
+	Default bool `graphql:"default" json:"default"`
 }
 
 // BindingExecutionConfigSecurityCotnext holds the security context configuration for a binding execution config.
 type BindingExecutionConfigSecurityContext struct {
-	Default string `json:"default"`
+	Default string `graphql:"default" json:"default"`
 }
 
 // BindingExecutionConfigResourceLimits holds the resource limits configuration for a binding execution config.
 type BindingExecutionConfigResourceLimits struct {
-	Default         *BindingExecutionConfigResourceLimit                  `json:"default"`
-	PolicyOverrides []BindingExecutionConfigResourceLimitsPolicyOverrides `json:"policyOverrides"`
+	Default         *BindingExecutionConfigResourceLimit                  `graphql:"default" json:"default"`
+	PolicyOverrides []BindingExecutionConfigResourceLimitsPolicyOverrides `graphql:"policyOverrides" json:"policyOverrides"`
 }
 
 // BindingExecutionConfigResourceLimit holds resource limits for a binding execution config.
 type BindingExecutionConfigResourceLimit struct {
-	MaxCount      *int32   `json:"maxCount,omitempty"`
-	MaxPercentage *float32 `json:"maxPercentage,omitempty"`
-	RequiresBoth  bool     `json:"requiresBoth"`
+	MaxCount      *int32   `graphql:"maxCount" json:"maxCount,omitempty"`
+	MaxPercentage *float32 `graphql:"maxPercentage" json:"maxPercentage,omitempty"`
+	RequiresBoth  bool     `graphql:"requiresBoth" json:"requiresBoth"`
 }
 
 // BindingExecutionConfigResourceLimitsPolicyOverrides holds resource limits
 // policy overrides for a binding execution config.
 type BindingExecutionConfigResourceLimitsPolicyOverrides struct {
-	Limit      BindingExecutionConfigResourceLimit `json:"limit"`
-	PolicyName string                              `json:"policyName"`
+	Limit      BindingExecutionConfigResourceLimit `graphql:"limit" json:"limit"`
+	PolicyName string                              `graphql:"policyName" json:"policyName"`
 }
 
 // BindingCreateInput is the input for creating a binding.

--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -12,10 +12,10 @@ import (
 
 // TerraformModule is the data returned for terraform module definitions.
 type TerraformModule struct {
-	RepositoryURL string `graphql:"repositoryURL"`
+	RepositoryURL string
 	Source        string
 	Version       *string
-	VariablesJSON string `graphql:"variablesJSON"`
+	VariablesJSON string
 }
 
 // Tag is the data for a tag.

--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -12,10 +12,10 @@ import (
 
 // TerraformModule is the data returned for terraform module definitions.
 type TerraformModule struct {
-	RepositoryURL string
-	Source        string
-	Version       *string
-	VariablesJSON string
+	RepositoryURL string  `graphql:"repositoryURL"`
+	Source        string  `graphql:"source"`
+	Version       *string `graphql:"version"`
+	VariablesJSON string  `graphql:"variablesJSON"`
 }
 
 // Tag is the data for a tag.

--- a/internal/api/configuration_profile.go
+++ b/internal/api/configuration_profile.go
@@ -13,8 +13,8 @@ type UUID string
 
 // ConfigurationProfile is the data returned for configuration profiles.
 type ConfigurationProfile struct {
-	ID      graphql.ID
-	Profile string
+	ID      graphql.ID `graphql:"id"`
+	Profile string     `graphql:"profile"`
 	Record  struct {
 		TypeName                   string                     `graphql:"__typename"`
 		EmailConfiguration         EmailConfiguration         `graphql:"... on EmailConfiguration"`
@@ -30,55 +30,55 @@ type ConfigurationProfile struct {
 
 // EmailConfiguration is the configuration for email profiles.
 type EmailConfiguration struct {
-	FromEmail string             `json:"fromEmail"`
+	FromEmail string             `graphql:"fromEmail" json:"fromEmail"`
 	SESRegion *string            `graphql:"sesRegion" json:"sesRegion"`
 	SMTP      *SMTPConfiguration `graphql:"smtp" json:"smtp"`
 }
 
 // SMTPConfiguration is the SMTP server configuration.
 type SMTPConfiguration struct {
-	Server   string  `json:"server"`
-	Port     string  `json:"port"`
+	Server   string  `graphql:"server" json:"server"`
+	Port     string  `graphql:"port" json:"port"`
 	SSL      *bool   `graphql:"ssl" json:"ssl"`
-	Username *string `json:"username"`
-	Password *string `json:"password"`
+	Username *string `graphql:"username" json:"username"`
+	Password *string `graphql:"password" json:"password"`
 }
 
 // ServiceNowConfiguration is the configuration for ServiceNow profiles.
 type ServiceNowConfiguration struct {
-	Endpoint    string `json:"endpoint"`
-	User        string `json:"user"`
-	Password    string `json:"password"`
-	IssueType   string `json:"issueType"`
-	ClosedState string `json:"closedState"`
+	Endpoint    string `graphql:"endpoint" json:"endpoint"`
+	User        string `graphql:"user" json:"user"`
+	Password    string `graphql:"password" json:"password"`
+	IssueType   string `graphql:"issueType" json:"issueType"`
+	ClosedState string `graphql:"closedState" json:"closedState"`
 }
 
 // SymphonyConfiguration is the configuration for Symphony profiles.
 type SymphonyConfiguration struct {
-	AgentDomain    string `json:"agentDomain"`
-	ServiceAccount string `json:"serviceAccount"`
-	PrivateKey     string `json:"privateKey"`
+	AgentDomain    string `graphql:"agentDomain" json:"agentDomain"`
+	ServiceAccount string `graphql:"serviceAccount" json:"serviceAccount"`
+	PrivateKey     string `graphql:"privateKey" json:"privateKey"`
 }
 
 // SlackConfiguration is the configuration for Slack profiles.
 type SlackConfiguration struct {
-	Token      *string        `json:"token"`
-	UserFields []string       `json:"userFields"`
-	Webhooks   []SlackWebhook `json:"webhooks"`
+	Token      *string        `graphql:"token" json:"token"`
+	UserFields []string       `graphql:"userFields" json:"userFields"`
+	Webhooks   []SlackWebhook `graphql:"webhooks" json:"webhooks"`
 }
 
 // SlackWebhook is a webhook configuration for Slack.
 type SlackWebhook struct {
-	Name string `json:"name"`
+	Name string `graphql:"name" json:"name"`
 	URL  string `graphql:"url" json:"url"`
 }
 
 // MSTeamsConfiguration is the configuration for Microsoft Teams profiles.
 type MSTeamsConfiguration struct {
-	AccessConfig    *MSTeamsAccessConfig
-	CustomerConfig  MSTeamsCustomerConfig
-	ChannelMappings []MSTeamsChannelMapping
-	EntityDetails   MSTeamsEntityDetails
+	AccessConfig    *MSTeamsAccessConfig    `graphql:"accessConfig"`
+	CustomerConfig  MSTeamsCustomerConfig   `graphql:"customerConfig"`
+	ChannelMappings []MSTeamsChannelMapping `graphql:"channelMappings"`
+	EntityDetails   MSTeamsEntityDetails    `graphql:"entityDetails"`
 }
 
 // MSTeamsAccessConfigInput is the input for the access configuration for
@@ -99,58 +99,58 @@ type MSTeamsCustomerConfigInput struct {
 type MSTeamsAccessConfig struct {
 	MSTeamsAccessConfigInput
 
-	BotApplication       MSTeamsBotApplication
-	PublishedApplication MSTeamsPublishedApplicationPayload
+	BotApplication       MSTeamsBotApplication              `graphql:"botApplication"`
+	PublishedApplication MSTeamsPublishedApplicationPayload `graphql:"publishedApplication"`
 }
 
 // MSTeamsBotApplication contains details about the Microsoft Teams bot application.
 type MSTeamsBotApplication struct {
-	DownloadURL string
-	Version     string
+	DownloadURL string `graphql:"downloadURL"`
+	Version     string `graphql:"version"`
 }
 
 // MSTeamsPublishedApplicationPayload contains details about the Microsoft Teams bot application publishing to the registry.
 type MSTeamsPublishedApplicationPayload struct {
-	Application *MSTeamsPublishedApplication
+	Application *MSTeamsPublishedApplication `graphql:"application"`
 }
 
 // MSTeamsPublishedApplication contains details about the Microsoft Teams bot application publishing to the registry.
 type MSTeamsPublishedApplication struct {
-	CatalogID *string
-	Version   *string
+	CatalogID *string `graphql:"catalogId"`
+	Version   *string `graphql:"version"`
 }
 
 // MSTeamsCustomerConfig is the customer configuration for Microsoft Teams profile setup.
 type MSTeamsCustomerConfig struct {
 	MSTeamsCustomerConfigInput
 
-	RoundtripDigest string
-	TerraformModule TerraformModule
+	RoundtripDigest string          `graphql:"roundtripDigest"`
+	TerraformModule TerraformModule `graphql:"terraformModule"`
 }
 
 // MSTeamsEntityDetails has details about Microsoft Teams entities from their ID.
 type MSTeamsEntityDetails struct {
-	Channels []MSTeamsChannelDetail
-	Teams    []MSTeamsTeamDetail
+	Channels []MSTeamsChannelDetail `graphql:"channels"`
+	Teams    []MSTeamsTeamDetail    `graphql:"teams"`
 }
 
 // MSTeamsChannelDetail has details about a Microsoft Teams channel.
 type MSTeamsChannelDetail struct {
-	ID   string
-	Name string
+	ID   string `graphql:"id"`
+	Name string `graphql:"name"`
 }
 
 // MSTeamsTeamDetail has details about a Microsoft Teams team.
 type MSTeamsTeamDetail struct {
-	ID   string
-	Name string
+	ID   string `graphql:"id"`
+	Name string `graphql:"name"`
 }
 
 // MSTeamsChannelMapping contains mappings between IDs and target names for Microsoft Teams.
 type MSTeamsChannelMapping struct {
-	Name      string `json:"name"`
-	TeamID    UUID   `json:"teamId"`
-	ChannelID string `json:"channelId"`
+	Name      string `graphql:"name" json:"name"`
+	TeamID    UUID   `graphql:"teamId" json:"teamId"`
+	ChannelID string `graphql:"channelId" json:"channelId"`
 }
 
 // MSTeamsConfigurationInput is the configuration input for the Microsoft Teams profile.
@@ -174,17 +174,17 @@ func (i msteamsConfigurationInput) GetGraphQLType() string {
 // JiraConfiguration is the configuration for Jira profiles.
 type JiraConfiguration struct {
 	URL      *string       `graphql:"url" json:"url"`
-	Projects []JiraProject `json:"projects"`
-	User     string        `json:"user"`
-	APIKey   string        `json:"apiKey"`
+	Projects []JiraProject `graphql:"projects" json:"projects"`
+	User     string        `graphql:"user" json:"user"`
+	APIKey   string        `graphql:"apiKey" json:"apiKey"`
 }
 
 // JiraProject is the configuration for a Jira project.
 type JiraProject struct {
-	ClosedStatus string `json:"closedStatus"`
-	IssueType    string `json:"issueType"`
-	Name         string `json:"name"`
-	Project      string `json:"project"`
+	ClosedStatus string `graphql:"closedStatus" json:"closedStatus"`
+	IssueType    string `graphql:"issueType" json:"issueType"`
+	Name         string `graphql:"name" json:"name"`
+	Project      string `graphql:"project" json:"project"`
 }
 
 type jiraConfigurationInput struct {
@@ -202,9 +202,9 @@ func (i jiraConfigurationInput) GetGraphQLType() string {
 type ResourceOwnerConfiguration struct {
 	// "default" is present with different type in both resource and account, so it must be aliased
 	Default      []string `graphql:"resourceOwnerDefault: default" json:"default"`
-	OrgDomain    *string  `json:"orgDomain"`
-	OrgDomainTag *string  `json:"orgDomainTag"`
-	Tags         []string `json:"tags"`
+	OrgDomain    *string  `graphql:"orgDomain" json:"orgDomain"`
+	OrgDomainTag *string  `graphql:"orgDomainTag" json:"orgDomainTag"`
+	Tags         []string `graphql:"tags" json:"tags"`
 }
 
 type resourceOwnerConfigurationInput struct {
@@ -222,15 +222,15 @@ func (i resourceOwnerConfigurationInput) GetGraphQLType() string {
 type AccountOwnersConfiguration struct {
 	// "default" is present with different type in both resource and account, so it must be aliased
 	Default      []AccountOwners `graphql:"accountOwnersDefault: default" json:"default"`
-	OrgDomain    *string         `json:"orgDomain"`
-	OrgDomainTag *string         `json:"orgDomainTag"`
-	Tags         []string        `json:"tags"`
+	OrgDomain    *string         `graphql:"orgDomain" json:"orgDomain"`
+	OrgDomainTag *string         `graphql:"orgDomainTag" json:"orgDomainTag"`
+	Tags         []string        `graphql:"tags" json:"tags"`
 }
 
 // AccountOwners tracks the owners for an account.
 type AccountOwners struct {
-	Account string   `json:"account"`
-	Owners  []string `json:"owners"`
+	Account string   `graphql:"account" json:"account"`
+	Owners  []string `graphql:"owners" json:"owners"`
 }
 
 type accountOwnersConfigurationInput struct {

--- a/internal/api/configuration_profile.go
+++ b/internal/api/configuration_profile.go
@@ -75,10 +75,10 @@ type SlackWebhook struct {
 
 // MSTeamsConfiguration is the configuration for Microsoft Teams profiles.
 type MSTeamsConfiguration struct {
-	AccessConfig    *MSTeamsAccessConfig    `json:"accessConfig"`
-	CustomerConfig  MSTeamsCustomerConfig   `json:"customerConfig"`
-	ChannelMappings []MSTeamsChannelMapping `json:"channelMappings"`
-	EntityDetails   MSTeamsEntityDetails    `json:"entityDetails"`
+	AccessConfig    *MSTeamsAccessConfig
+	CustomerConfig  MSTeamsCustomerConfig
+	ChannelMappings []MSTeamsChannelMapping
+	EntityDetails   MSTeamsEntityDetails
 }
 
 // MSTeamsAccessConfigInput is the input for the access configuration for
@@ -99,51 +99,51 @@ type MSTeamsCustomerConfigInput struct {
 type MSTeamsAccessConfig struct {
 	MSTeamsAccessConfigInput
 
-	BotApplication       MSTeamsBotApplication              `json:"botApplication"`
-	PublishedApplication MSTeamsPublishedApplicationPayload `json:"publishedApplication"`
+	BotApplication       MSTeamsBotApplication
+	PublishedApplication MSTeamsPublishedApplicationPayload
 }
 
 // MSTeamsBotApplication contains details about the Microsoft Teams bot application.
 type MSTeamsBotApplication struct {
-	DownloadURL string `graphql:"downloadURL" json:"downloadURL"`
-	Version     string `json:"version"`
+	DownloadURL string
+	Version     string
 }
 
 // MSTeamsPublishedApplicationPayload contains details about the Microsoft Teams bot application publishing to the registry.
 type MSTeamsPublishedApplicationPayload struct {
-	Application *MSTeamsPublishedApplication `json:"application"`
+	Application *MSTeamsPublishedApplication
 }
 
 // MSTeamsPublishedApplication contains details about the Microsoft Teams bot application publishing to the registry.
 type MSTeamsPublishedApplication struct {
-	CatalogID *string `json:"catalogID"`
-	Version   *string `json:"version"`
+	CatalogID *string
+	Version   *string
 }
 
 // MSTeamsCustomerConfig is the customer configuration for Microsoft Teams profile setup.
 type MSTeamsCustomerConfig struct {
 	MSTeamsCustomerConfigInput
 
-	RoundtripDigest string          `json:"roundtripDigest"`
-	TerraformModule TerraformModule `json:"terraformModule"`
+	RoundtripDigest string
+	TerraformModule TerraformModule
 }
 
 // MSTeamsEntityDetails has details about Microsoft Teams entities from their ID.
 type MSTeamsEntityDetails struct {
-	Channels []MSTeamsChannelDetail `json:"channels"`
-	Teams    []MSTeamsTeamDetail    `json:"teams"`
+	Channels []MSTeamsChannelDetail
+	Teams    []MSTeamsTeamDetail
 }
 
 // MSTeamsChannelDetail has details about a Microsoft Teams channel.
 type MSTeamsChannelDetail struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID   string
+	Name string
 }
 
 // MSTeamsTeamDetail has details about a Microsoft Teams team.
 type MSTeamsTeamDetail struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID   string
+	Name string
 }
 
 // MSTeamsChannelMapping contains mappings between IDs and target names for Microsoft Teams.

--- a/internal/api/gcp_integration.go
+++ b/internal/api/gcp_integration.go
@@ -38,10 +38,10 @@ type GCPIntegrationCustomerInfrastructure struct {
 // GCPIntegrationCustomerCreateProject holds configuration for integration
 // project creation.
 type GCPIntegrationCustomerCreateProject struct {
-	BillingAccountID string   `graphql:"billingAccountId"`
-	OrgID            *string  `graphql:"orgId"`
-	FolderID         *string  `graphql:"folderId"`
-	Labels           TagsList `graphql:"labels"`
+	BillingAccountID string  `graphql:"billingAccountId"`
+	OrgID            *string `graphql:"orgId"`
+	FolderID         *string `graphql:"folderId"`
+	Labels           TagsList
 }
 
 // GCPIntegrationCustomerOrganization identifies a GCP organization Stacklet will manage.

--- a/internal/api/gcp_integration.go
+++ b/internal/api/gcp_integration.go
@@ -10,38 +10,38 @@ import (
 
 // GCPIntegration is the data for a GCP integration.
 type GCPIntegration struct {
-	ID             graphql.ID
-	Key            string
-	CustomerConfig GCPIntegrationCustomerConfig
-	AccessConfig   *GCPIntegrationAccessConfig
+	ID             graphql.ID                   `graphql:"id"`
+	Key            string                       `graphql:"key"`
+	CustomerConfig GCPIntegrationCustomerConfig `graphql:"customerConfig"`
+	AccessConfig   *GCPIntegrationAccessConfig  `graphql:"accessConfig"`
 }
 
 // GCPIntegrationCustomerConfig defines the customer-provided configuration for
 // the GCP integration.
 type GCPIntegrationCustomerConfig struct {
-	Infrastructure   *GCPIntegrationCustomerInfrastructure
-	Organizations    []GCPIntegrationCustomerOrganization
-	CostSources      []GCPIntegrationCustomerCostSource
-	SecurityContexts []GCPIntegrationCustomerSecurityContext
-	TerraformModule  *TerraformModule
+	Infrastructure   *GCPIntegrationCustomerInfrastructure   `graphql:"infrastructure"`
+	Organizations    []GCPIntegrationCustomerOrganization    `graphql:"organizations"`
+	CostSources      []GCPIntegrationCustomerCostSource      `graphql:"costSources"`
+	SecurityContexts []GCPIntegrationCustomerSecurityContext `graphql:"securityContexts"`
+	TerraformModule  *TerraformModule                        `graphql:"terraformModule"`
 }
 
 // GCPIntegrationCustomerInfrastructure defines the project configuration for
 // the GCP integration deployment.
 type GCPIntegrationCustomerInfrastructure struct {
-	ProjectID        string `graphql:"projectId"`
-	ResourceLocation string
-	ResourcePrefix   string
-	CreateProject    *GCPIntegrationCustomerCreateProject
+	ProjectID        string                               `graphql:"projectId"`
+	ResourceLocation string                               `graphql:"resourceLocation"`
+	ResourcePrefix   string                               `graphql:"resourcePrefix"`
+	CreateProject    *GCPIntegrationCustomerCreateProject `graphql:"createProject"`
 }
 
 // GCPIntegrationCustomerCreateProject holds configuration for integration
 // project creation.
 type GCPIntegrationCustomerCreateProject struct {
-	BillingAccountID string  `graphql:"billingAccountId"`
-	OrgID            *string `graphql:"orgId"`
-	FolderID         *string `graphql:"folderId"`
-	Labels           TagsList
+	BillingAccountID string   `graphql:"billingAccountId"`
+	OrgID            *string  `graphql:"orgId"`
+	FolderID         *string  `graphql:"folderId"`
+	Labels           TagsList `graphql:"labels"`
 }
 
 // GCPIntegrationCustomerOrganization identifies a GCP organization Stacklet will manage.
@@ -53,32 +53,32 @@ type GCPIntegrationCustomerOrganization struct {
 
 // GCPIntegrationCustomerCostSource identifies a billing export table for cost data.
 type GCPIntegrationCustomerCostSource struct {
-	BillingTable string
+	BillingTable string `graphql:"billingTable"`
 }
 
 // GCPIntegrationCustomerSecurityContext defines additional security context to
 // define in the integration.
 type GCPIntegrationCustomerSecurityContext struct {
-	Name       string
-	ExtraRoles []string
+	Name       string   `graphql:"name"`
+	ExtraRoles []string `graphql:"extraRoles"`
 }
 
 // GCPIntegrationAccessConfig holds the access details from the GCP
 // integration.
 type GCPIntegrationAccessConfig struct {
-	Infrastructure   GCPIntegrationAccessInfrastructure
-	Organizations    []GCPIntegrationAccessOrganization
-	CostSources      []GCPIntegrationAccessCostSource
-	SecurityContexts []GCPIntegrationAccessSecurityContext
-	RoundtripDigest  string
+	Infrastructure   GCPIntegrationAccessInfrastructure    `graphql:"infrastructure"`
+	Organizations    []GCPIntegrationAccessOrganization    `graphql:"organizations"`
+	CostSources      []GCPIntegrationAccessCostSource      `graphql:"costSources"`
+	SecurityContexts []GCPIntegrationAccessSecurityContext `graphql:"securityContexts"`
+	RoundtripDigest  string                                `graphql:"roundtripDigest"`
 }
 
 // GCPIntegrationAccessInfrastructure identifies the GCP infrastructure project.
 type GCPIntegrationAccessInfrastructure struct {
-	ProjectID     string `graphql:"projectId"`
-	Relay         GCPIntegrationAccessRelay
-	WIF           GCPIntegrationAccessWIF `graphql:"wif"`
-	BaselineRoles []string
+	ProjectID     string                    `graphql:"projectId"`
+	Relay         GCPIntegrationAccessRelay `graphql:"relay"`
+	WIF           GCPIntegrationAccessWIF   `graphql:"wif"`
+	BaselineRoles []string                  `graphql:"baselineRoles"`
 }
 
 // GCPIntegrationAccessRelay holds the relay identity credential.
@@ -88,47 +88,47 @@ type GCPIntegrationAccessRelay struct {
 
 // GCPIntegrationAccessWIF holds the Workload Identity Federation configuration.
 type GCPIntegrationAccessWIF struct {
-	Audience   string
-	Principals GCPIntegrationAccessWIFPrincipals
+	Audience   string                            `graphql:"audience"`
+	Principals GCPIntegrationAccessWIFPrincipals `graphql:"principals"`
 }
 
 // GCPIntegrationAccessWIFPrincipals identifies WIF principals by their intended role.
 type GCPIntegrationAccessWIFPrincipals struct {
-	ReadOnly  string
-	CostQuery string
+	ReadOnly  string `graphql:"readOnly"`
+	CostQuery string `graphql:"costQuery"`
 }
 
 // GCPIntegrationAccessOrganization identifies an accessible GCP organization.
 type GCPIntegrationAccessOrganization struct {
-	ID       string
-	Name     string
-	Folders  []GCPIntegrationAccessOrganizationFolder
-	Projects []GCPIntegrationAccessOrganizationProject
+	ID       string                                    `graphql:"id"`
+	Name     string                                    `graphql:"name"`
+	Folders  []GCPIntegrationAccessOrganizationFolder  `graphql:"folders"`
+	Projects []GCPIntegrationAccessOrganizationProject `graphql:"projects"`
 }
 
 // GCPIntegrationAccessOrganizationFolder provides details about a connected organization folder.
 type GCPIntegrationAccessOrganizationFolder struct {
-	ID   string
-	Name string
+	ID   string `graphql:"id"`
+	Name string `graphql:"name"`
 }
 
 // GCPIntegrationAccessOrganizationProject provides details about a connected organization project.
 type GCPIntegrationAccessOrganizationProject struct {
-	ID     string
-	Number string
+	ID     string `graphql:"id"`
+	Number string `graphql:"number"`
 }
 
 // GCPIntegrationAccessCostSource identifies a billing export table and its location.
 type GCPIntegrationAccessCostSource struct {
-	BillingTable string
-	Location     string
+	BillingTable string `graphql:"billingTable"`
+	Location     string `graphql:"location"`
 }
 
 // GCPIntegrationAccessSecurityContext defines a named set of roles granted to a principal.
 type GCPIntegrationAccessSecurityContext struct {
-	Name       string
-	ExtraRoles []string
-	Principal  string
+	Name       string   `graphql:"name"`
+	ExtraRoles []string `graphql:"extraRoles"`
+	Principal  string   `graphql:"principal"`
 }
 
 // GCPIntegrationInput is the input for creating or updating a GCP integration.

--- a/internal/api/notification_template.go
+++ b/internal/api/notification_template.go
@@ -10,11 +10,11 @@ import (
 
 // Template is the data returned for a notification template.
 type Template struct {
-	ID          graphql.ID
-	Name        string
-	Description *string
-	Transport   *string
-	Content     string
+	ID          graphql.ID `graphql:"id"`
+	Name        string     `graphql:"name"`
+	Description *string    `graphql:"description"`
+	Transport   *string    `graphql:"transport"`
+	Content     string     `graphql:"content"`
 }
 
 // TemplateCreateInput is the input for creating a template.

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -21,7 +21,7 @@ type Policy struct {
 	ResourceType    string
 	Path            string
 	Source          string
-	SourceYAML      string `graphql:"sourceYAML"`
+	SourceYAML      string
 	System          bool
 	UnqualifiedName string
 }

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -10,20 +10,20 @@ import (
 
 // Policy is the data returned by reading policy data.
 type Policy struct {
-	ID              graphql.ID
-	UUID            string
-	Name            string
-	Description     *string
-	Provider        string
-	Version         int
-	Category        []string
-	Mode            string
-	ResourceType    string
-	Path            string
-	Source          string
-	SourceYAML      string
-	System          bool
-	UnqualifiedName string
+	ID              graphql.ID `graphql:"id"`
+	UUID            string     `graphql:"uuid"`
+	Name            string     `graphql:"name"`
+	Description     *string    `graphql:"description"`
+	Provider        string     `graphql:"provider"`
+	Version         int        `graphql:"version"`
+	Category        []string   `graphql:"category"`
+	Mode            string     `graphql:"mode"`
+	ResourceType    string     `graphql:"resourceType"`
+	Path            string     `graphql:"path"`
+	Source          string     `graphql:"source"`
+	SourceYAML      string     `graphql:"sourceYAML"`
+	System          bool       `graphql:"system"`
+	UnqualifiedName string     `graphql:"unqualifiedName"`
 }
 
 type policyAPI struct {

--- a/internal/api/policy_collection.go
+++ b/internal/api/policy_collection.go
@@ -10,19 +10,19 @@ import (
 
 // Account is the data returned by reading policy collection data.
 type PolicyCollection struct {
-	ID               graphql.ID
-	UUID             string
-	Name             string
-	Description      *string
-	Provider         CloudProvider
-	AutoUpdate       bool
-	System           bool
-	IsDynamic        bool
+	ID               graphql.ID    `graphql:"id"`
+	UUID             string        `graphql:"uuid"`
+	Name             string        `graphql:"name"`
+	Description      *string       `graphql:"description"`
+	Provider         CloudProvider `graphql:"provider"`
+	AutoUpdate       bool          `graphql:"autoUpdate"`
+	System           bool          `graphql:"system"`
+	IsDynamic        bool          `graphql:"isDynamic"`
 	RepositoryConfig struct {
-		UUID *string
-	}
-	RepositoryView       *RepositoryView
-	RoleAssignmentTarget string
+		UUID *string `graphql:"uuid"`
+	} `graphql:"repositoryConfig"`
+	RepositoryView       *RepositoryView `graphql:"repositoryView"`
+	RoleAssignmentTarget string          `graphql:"roleAssignmentTarget"`
 }
 
 type RepositoryViewConfig struct {

--- a/internal/api/policy_collection_mapping.go
+++ b/internal/api/policy_collection_mapping.go
@@ -10,14 +10,14 @@ import (
 
 // PolicyCollectionMapping is the data returned by reading a policy collection mapping.
 type PolicyCollectionMapping struct {
-	ID     graphql.ID
+	ID     graphql.ID `graphql:"id"`
 	Policy struct {
-		UUID    string
-		Version int
-	}
+		UUID    string `graphql:"uuid"`
+		Version int    `graphql:"version"`
+	} `graphql:"policy"`
 	Collection struct {
-		UUID string
-	}
+		UUID string `graphql:"uuid"`
+	} `graphql:"collection"`
 }
 
 // PolicyCollectionMappingInput is the input for creating or updating a policy collection mapping.

--- a/internal/api/report_group.go
+++ b/internal/api/report_group.go
@@ -10,14 +10,14 @@ import (
 
 // ReportGroup is the data for a notification report group.
 type ReportGroup struct {
-	ID                 graphql.ID
-	Name               string
-	Enabled            bool
-	Bindings           []string
-	Source             ReportSource
-	Schedule           string
-	GroupBy            []string
-	UseMessageSettings bool
+	ID                 graphql.ID   `graphql:"id"`
+	Name               string       `graphql:"name"`
+	Enabled            bool         `graphql:"enabled"`
+	Bindings           []string     `graphql:"bindings"`
+	Source             ReportSource `graphql:"source"`
+	Schedule           string       `graphql:"schedule"`
+	GroupBy            []string     `graphql:"groupBy"`
+	UseMessageSettings bool         `graphql:"useMessageSettings"`
 	DeliverySettings   []struct {
 		TypeName                   string                     `graphql:"__typename"`
 		EmailDeliverySettings      EmailDeliverySettings      `graphql:"... on EmailSettings"`
@@ -26,7 +26,7 @@ type ReportGroup struct {
 		ServiceNowDeliverySettings ServiceNowDeliverySettings `graphql:"... on ServiceNowSettings"`
 		JiraDeliverySettings       JiraDeliverySettings       `graphql:"... on JiraSettings"`
 		SymphonyDeliverySettings   SymphonyDeliverySettings   `graphql:"... on SymphonySettings"`
-	}
+	} `graphql:"deliverySettings"`
 }
 
 // EmailDeliverySettings returns the list of email delivery settings for the
@@ -102,50 +102,50 @@ func (r ReportGroup) SymphonyDeliverySettings() []SymphonyDeliverySettings {
 }
 
 type EmailDeliverySettings struct {
-	CC             []string    `json:"cc"`
-	FirstMatchOnly *bool       `json:"firstMatchOnly"`
-	Format         *string     `json:"format"`
-	FromEmail      *string     `json:"fromEmail"`
-	Priority       *string     `json:"priority"`
-	Recipients     []Recipient `json:"recipients"`
-	Subject        string      `json:"subject"`
-	Template       string      `json:"template"`
+	CC             []string    `graphql:"cc" json:"cc"`
+	FirstMatchOnly *bool       `graphql:"firstMatchOnly" json:"firstMatchOnly"`
+	Format         *string     `graphql:"format" json:"format"`
+	FromEmail      *string     `graphql:"fromEmail" json:"fromEmail"`
+	Priority       *string     `graphql:"priority" json:"priority"`
+	Recipients     []Recipient `graphql:"recipients" json:"recipients"`
+	Subject        string      `graphql:"subject" json:"subject"`
+	Template       string      `graphql:"template" json:"template"`
 }
 
 type SlackDeliverySettings struct {
-	FirstMatchOnly *bool       `json:"firstMatchOnly"`
-	Recipients     []Recipient `json:"recipients"`
-	Template       string      `json:"template"`
+	FirstMatchOnly *bool       `graphql:"firstMatchOnly" json:"firstMatchOnly"`
+	Recipients     []Recipient `graphql:"recipients" json:"recipients"`
+	Template       string      `graphql:"template" json:"template"`
 }
 
 type MSTeamsDeliverySettings struct {
-	FirstMatchOnly *bool       `json:"firstMatchOnly"`
-	Recipients     []Recipient `json:"recipients"`
-	Template       string      `json:"template"`
+	FirstMatchOnly *bool       `graphql:"firstMatchOnly" json:"firstMatchOnly"`
+	Recipients     []Recipient `graphql:"recipients" json:"recipients"`
+	Template       string      `graphql:"template" json:"template"`
 }
 
 type ServiceNowDeliverySettings struct {
-	FirstMatchOnly   *bool       `json:"firstMatchOnly"`
-	Impact           string      `json:"impact"`
-	Recipients       []Recipient `json:"recipients"`
-	ShortDescription string      `json:"shortDescription"`
-	Template         string      `json:"template"`
-	Urgency          string      `json:"urgency"`
+	FirstMatchOnly   *bool       `graphql:"firstMatchOnly" json:"firstMatchOnly"`
+	Impact           string      `graphql:"impact" json:"impact"`
+	Recipients       []Recipient `graphql:"recipients" json:"recipients"`
+	ShortDescription string      `graphql:"shortDescription" json:"shortDescription"`
+	Template         string      `graphql:"template" json:"template"`
+	Urgency          string      `graphql:"urgency" json:"urgency"`
 }
 
 type JiraDeliverySettings struct {
-	FirstMatchOnly *bool       `json:"firstMatchOnly"`
-	Recipients     []Recipient `json:"recipients"`
-	Template       string      `json:"template"`
-	Description    string      `json:"description"`
-	Project        string      `json:"project"`
-	Summary        string      `json:"summary"`
+	FirstMatchOnly *bool       `graphql:"firstMatchOnly" json:"firstMatchOnly"`
+	Recipients     []Recipient `graphql:"recipients" json:"recipients"`
+	Template       string      `graphql:"template" json:"template"`
+	Description    string      `graphql:"description" json:"description"`
+	Project        string      `graphql:"project" json:"project"`
+	Summary        string      `graphql:"summary" json:"summary"`
 }
 
 type SymphonyDeliverySettings struct {
-	FirstMatchOnly *bool       `json:"firstMatchOnly"`
-	Recipients     []Recipient `json:"recipients"`
-	Template       string      `json:"template"`
+	FirstMatchOnly *bool       `graphql:"firstMatchOnly" json:"firstMatchOnly"`
+	Recipients     []Recipient `graphql:"recipients" json:"recipients"`
+	Template       string      `graphql:"template" json:"template"`
 }
 
 // ReportGroupsInput is the input to create or update a report group.
@@ -169,8 +169,8 @@ type Recipient struct {
 	AccountOwner  *bool   `graphql:"account_owner" json:"account_owner"`
 	EventOwner    *bool   `graphql:"event_owner" json:"event_owner"`
 	ResourceOwner *bool   `graphql:"resource_owner" json:"resource_owner"`
-	Tag           *string `json:"tag"`
-	Value         *string `json:"value"`
+	Tag           *string `graphql:"tag" json:"tag"`
+	Value         *string `graphql:"value" json:"value"`
 }
 
 type upsertReportGroupsInput struct {

--- a/internal/api/repository.go
+++ b/internal/api/repository.go
@@ -10,30 +10,30 @@ import (
 )
 
 type Repository struct {
-	ID                   graphql.ID
-	UUID                 string
-	URL                  string
-	Name                 string
-	Description          *string
-	WebhookURL           string
-	System               bool
-	RoleAssignmentTarget string
+	ID                   graphql.ID `graphql:"id"`
+	UUID                 string     `graphql:"uuid"`
+	URL                  string     `graphql:"url"`
+	Name                 string     `graphql:"name"`
+	Description          *string    `graphql:"description"`
+	WebhookURL           string     `graphql:"webhookURL"`
+	System               bool       `graphql:"system"`
+	RoleAssignmentTarget string     `graphql:"roleAssignmentTarget"`
 
 	Auth struct {
-		AuthUser         *string
-		HasAuthToken     bool
-		SSHPublicKey     *string
-		HasSshPrivateKey bool
-		HasSshPassphrase bool
-	}
+		AuthUser         *string `graphql:"authUser"`
+		HasAuthToken     bool    `graphql:"hasAuthToken"`
+		SSHPublicKey     *string `graphql:"sshPublicKey"`
+		HasSshPrivateKey bool    `graphql:"hasSshPrivateKey"`
+		HasSshPassphrase bool    `graphql:"hasSshPassphrase"`
+	} `graphql:"auth"`
 }
 
 // RepositoryView is the data returned by reading repository view data.
 type RepositoryView struct {
-	Namespace         string
-	BranchName        string
-	PolicyDirectories []string
-	PolicyFileSuffix  []string
+	Namespace         string   `graphql:"namespace"`
+	BranchName        string   `graphql:"branchName"`
+	PolicyDirectories []string `graphql:"policyDirectories"`
+	PolicyFileSuffix  []string `graphql:"policyFileSuffix"`
 }
 
 // RepositoryConfigAuthInput exists to allow us to set only the fields we want to

--- a/internal/api/repository.go
+++ b/internal/api/repository.go
@@ -15,7 +15,7 @@ type Repository struct {
 	URL                  string
 	Name                 string
 	Description          *string
-	WebhookURL           string `graphql:"webhookURL"`
+	WebhookURL           string
 	System               bool
 	RoleAssignmentTarget string
 

--- a/internal/api/role.go
+++ b/internal/api/role.go
@@ -10,10 +10,10 @@ import (
 
 // Role is the data returned by reading role data.
 type Role struct {
-	ID          graphql.ID
-	Name        string
-	Permissions []string
-	System      bool
+	ID          graphql.ID `graphql:"id"`
+	Name        string     `graphql:"name"`
+	Permissions []string   `graphql:"permissions"`
+	System      bool       `graphql:"system"`
 }
 
 type roleAPI struct {

--- a/internal/api/role_assignment.go
+++ b/internal/api/role_assignment.go
@@ -13,13 +13,13 @@ import (
 type RoleAssignment struct {
 	ID        graphql.ID
 	Role      Role
-	Principal rolePrincipal `graphql:"principal"`
-	Target    roleTarget    `graphql:"target"`
+	Principal rolePrincipal
+	Target    roleTarget
 }
 
 // rolePrincipalPrincipal contains the opaque roleAssignmentPrincipal string.
 type rolePrincipalPrincipal struct {
-	RoleAssignmentPrincipal string `graphql:"roleAssignmentPrincipal"`
+	RoleAssignmentPrincipal string
 }
 
 // rolePrincipal represents the GraphQL union type for RolePrincipal.
@@ -41,7 +41,7 @@ func (r *RoleAssignment) GetPrincipal() string {
 
 // roleTarget represents the GraphQL union type for target entities.
 type roleTarget struct {
-	RoleAssignmentTarget string          `graphql:"roleAssignmentTarget"`
+	RoleAssignmentTarget string
 	RoleScope            *roleTargetType `graphql:"... on RoleScope"`
 	AccountGroup         *roleTargetType `graphql:"... on AccountGroup"`
 	PolicyCollection     *roleTargetType `graphql:"... on PolicyCollection"`
@@ -51,7 +51,7 @@ type roleTarget struct {
 
 // roleTargetType is used for the union type matching.
 type roleTargetType struct {
-	RoleAssignmentTarget string `graphql:"roleAssignmentTarget"`
+	RoleAssignmentTarget string
 }
 
 // GetTarget extracts the opaque target identifier string.

--- a/internal/api/role_assignment.go
+++ b/internal/api/role_assignment.go
@@ -11,15 +11,15 @@ import (
 
 // RoleAssignment is the data returned by reading role assignment data.
 type RoleAssignment struct {
-	ID        graphql.ID
-	Role      Role
-	Principal rolePrincipal
-	Target    roleTarget
+	ID        graphql.ID    `graphql:"id"`
+	Role      Role          `graphql:"role"`
+	Principal rolePrincipal `graphql:"principal"`
+	Target    roleTarget    `graphql:"target"`
 }
 
 // rolePrincipalPrincipal contains the opaque roleAssignmentPrincipal string.
 type rolePrincipalPrincipal struct {
-	RoleAssignmentPrincipal string
+	RoleAssignmentPrincipal string `graphql:"roleAssignmentPrincipal"`
 }
 
 // rolePrincipal represents the GraphQL union type for RolePrincipal.
@@ -41,7 +41,7 @@ func (r *RoleAssignment) GetPrincipal() string {
 
 // roleTarget represents the GraphQL union type for target entities.
 type roleTarget struct {
-	RoleAssignmentTarget string
+	RoleAssignmentTarget string          `graphql:"roleAssignmentTarget"`
 	RoleScope            *roleTargetType `graphql:"... on RoleScope"`
 	AccountGroup         *roleTargetType `graphql:"... on AccountGroup"`
 	PolicyCollection     *roleTargetType `graphql:"... on PolicyCollection"`
@@ -51,7 +51,7 @@ type roleTarget struct {
 
 // roleTargetType is used for the union type matching.
 type roleTargetType struct {
-	RoleAssignmentTarget string
+	RoleAssignmentTarget string `graphql:"roleAssignmentTarget"`
 }
 
 // GetTarget extracts the opaque target identifier string.
@@ -80,8 +80,8 @@ func (i roleAssignmentInput) GetGraphQLType() string {
 
 // grantRoleAssignmentPayload represents the result of granting a role assignment.
 type grantRoleAssignmentPayload struct {
-	ErrorMessage   *string
-	RoleAssignment *RoleAssignment
+	ErrorMessage   *string         `graphql:"errorMessage"`
+	RoleAssignment *RoleAssignment `graphql:"roleAssignment"`
 }
 
 func (p grantRoleAssignmentPayload) Error() string {
@@ -94,10 +94,10 @@ func (p grantRoleAssignmentPayload) Error() string {
 
 // revokeRoleAssignmentPayload represents the result of revoking a role assignment.
 type revokeRoleAssignmentPayload struct {
-	ErrorMessage *string
+	ErrorMessage *string `graphql:"errorMessage"`
 	Removed      struct {
-		ID graphql.ID
-	}
+		ID graphql.ID `graphql:"id"`
+	} `graphql:"removed"`
 }
 
 func (p revokeRoleAssignmentPayload) Error() string {

--- a/internal/api/sso_group.go
+++ b/internal/api/sso_group.go
@@ -11,10 +11,10 @@ import (
 
 // SSOGroup is the data returned by reading SSO group data.
 type SSOGroup struct {
-	ID                      graphql.ID
-	DisplayName             *string
-	Name                    string
-	RoleAssignmentPrincipal string
+	ID                      graphql.ID `graphql:"id"`
+	DisplayName             *string    `graphql:"displayName"`
+	Name                    string     `graphql:"name"`
+	RoleAssignmentPrincipal string     `graphql:"roleAssignmentPrincipal"`
 }
 
 // SSOGroupInput is the input to create or update an SSO group.
@@ -36,8 +36,8 @@ func (i upsertSSOGroupInput) GetGraphQLType() string {
 }
 
 type upsertSSOGroupPayload struct {
-	ErrorMessage *string
-	SSOGroup     *SSOGroup
+	ErrorMessage *string   `graphql:"errorMessage"`
+	SSOGroup     *SSOGroup `graphql:"ssoGroup"`
 }
 
 func (p upsertSSOGroupPayload) Error() string {
@@ -49,7 +49,7 @@ func (p upsertSSOGroupPayload) Error() string {
 }
 
 type removeSSOGroupPayload struct {
-	ErrorMessage *string
+	ErrorMessage *string `graphql:"errorMessage"`
 }
 
 func (p removeSSOGroupPayload) Error() string {

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -10,45 +10,45 @@ import (
 
 // Platform is the data returned by reading platform data.
 type Platform struct {
-	ID                       graphql.ID
-	ExternalID               *string
-	ExecutionRegions         []string
+	ID                       graphql.ID             `graphql:"id"`
+	ExternalID               *string                `graphql:"externalID"`
+	ExecutionRegions         []string               `graphql:"executionRegions"`
 	AWSOrgReadCustomerConfig PlatformCustomerConfig `graphql:"awsOrgReadCustomerConfig"`
 	AWSAccountCustomerConfig PlatformCustomerConfig `graphql:"awsAccountCustomerConfig"`
 }
 
 // PlatformCustomerConfig is the data returned for a customer configuration.
 type PlatformCustomerConfig struct {
-	TerraformModule TerraformModule
+	TerraformModule TerraformModule `graphql:"terraformModule"`
 }
 
 // MSTeamsIntegrationSurface is the data returned by reading Microsoft Teams
 // integration configuration details.
 type MSTeamsIntegrationSurface struct {
-	BotEndpoint  string
+	BotEndpoint  string `graphql:"botEndpoint"`
 	WIFIssuerURL string `graphql:"wifIssuerURL"`
-	TrustRoleARN string
+	TrustRoleARN string `graphql:"trustRoleARN"`
 }
 
 // GCPIntegrationSurface is the data returned by reading GCP integration configuration details.
 type GCPIntegrationSurface struct {
-	TrustAws GCPIntegrationSurfaceTrustAws
-	AwsRelay GCPIntegrationSurfaceAwsRelay
+	TrustAws GCPIntegrationSurfaceTrustAws `graphql:"trustAws"`
+	AwsRelay GCPIntegrationSurfaceAwsRelay `graphql:"awsRelay"`
 }
 
 // GCPIntegrationSurfaceTrustAws holds AWS trust configuration for GCP integration.
 type GCPIntegrationSurfaceTrustAws struct {
 	AccountID         string `graphql:"accountId"`
-	AssetdbRoleName   string
-	CostQueryRoleName string
-	ExecutionRoleName string
-	PlatformRoleName  string
+	AssetdbRoleName   string `graphql:"assetdbRoleName"`
+	CostQueryRoleName string `graphql:"costQueryRoleName"`
+	ExecutionRoleName string `graphql:"executionRoleName"`
+	PlatformRoleName  string `graphql:"platformRoleName"`
 }
 
 // GCPIntegrationSurfaceAwsRelay holds AWS relay configuration for GCP integration.
 type GCPIntegrationSurfaceAwsRelay struct {
-	BusArn  string
-	RoleArn string
+	BusArn  string `graphql:"busArn"`
+	RoleArn string `graphql:"roleArn"`
 }
 
 type systemAPI struct {

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -11,7 +11,7 @@ import (
 // Platform is the data returned by reading platform data.
 type Platform struct {
 	ID                       graphql.ID
-	ExternalID               *string `graphql:"externalID"`
+	ExternalID               *string
 	ExecutionRegions         []string
 	AWSOrgReadCustomerConfig PlatformCustomerConfig `graphql:"awsOrgReadCustomerConfig"`
 	AWSAccountCustomerConfig PlatformCustomerConfig `graphql:"awsAccountCustomerConfig"`
@@ -25,30 +25,30 @@ type PlatformCustomerConfig struct {
 // MSTeamsIntegrationSurface is the data returned by reading Microsoft Teams
 // integration configuration details.
 type MSTeamsIntegrationSurface struct {
-	BotEndpoint  string `graphql:"botEndpoint"`
+	BotEndpoint  string
 	WIFIssuerURL string `graphql:"wifIssuerURL"`
-	TrustRoleARN string `graphql:"trustRoleARN"`
+	TrustRoleARN string
 }
 
 // GCPIntegrationSurface is the data returned by reading GCP integration configuration details.
 type GCPIntegrationSurface struct {
-	TrustAws GCPIntegrationSurfaceTrustAws `graphql:"trustAws"`
-	AwsRelay GCPIntegrationSurfaceAwsRelay `graphql:"awsRelay"`
+	TrustAws GCPIntegrationSurfaceTrustAws
+	AwsRelay GCPIntegrationSurfaceAwsRelay
 }
 
 // GCPIntegrationSurfaceTrustAws holds AWS trust configuration for GCP integration.
 type GCPIntegrationSurfaceTrustAws struct {
 	AccountID         string `graphql:"accountId"`
-	AssetdbRoleName   string `graphql:"assetdbRoleName"`
-	CostQueryRoleName string `graphql:"costQueryRoleName"`
-	ExecutionRoleName string `graphql:"executionRoleName"`
-	PlatformRoleName  string `graphql:"platformRoleName"`
+	AssetdbRoleName   string
+	CostQueryRoleName string
+	ExecutionRoleName string
+	PlatformRoleName  string
 }
 
 // GCPIntegrationSurfaceAwsRelay holds AWS relay configuration for GCP integration.
 type GCPIntegrationSurfaceAwsRelay struct {
-	BusArn  string `graphql:"busArn"`
-	RoleArn string `graphql:"roleArn"`
+	BusArn  string
+	RoleArn string
 }
 
 type systemAPI struct {

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -10,15 +10,15 @@ import (
 
 // User is the data returned by reading user data.
 type User struct {
-	ID                      graphql.ID
-	Active                  bool
-	DisplayName             *string
-	Email                   *string
-	Name                    *string
-	Key                     int64
-	RoleAssignmentPrincipal string
-	SSOUser                 bool
-	Username                *string
+	ID                      graphql.ID `graphql:"id"`
+	Active                  bool       `graphql:"active"`
+	DisplayName             *string    `graphql:"displayName"`
+	Email                   *string    `graphql:"email"`
+	Name                    *string    `graphql:"name"`
+	Key                     int64      `graphql:"key"`
+	RoleAssignmentPrincipal string     `graphql:"roleAssignmentPrincipal"`
+	SSOUser                 bool       `graphql:"ssoUser"`
+	Username                *string    `graphql:"username"`
 }
 
 // UserCreateInput is the input for creating a user.


### PR DESCRIPTION
### what

- add graphql tags to all related structs.
- remove json tags for structs that are not used as JSON input

### why

cleanups and easier match with API fields 

### testing

tests pass

### docs

n/a
