### PR TITLE
chore: add reusable workflow to run just command, use it for CI jobs

### DIFF
--- a/.github/workflows/_run-just.yaml
+++ b/.github/workflows/_run-just.yaml
@@ -1,0 +1,38 @@
+name: Run just command
+
+on:
+  workflow_call:
+    inputs:
+      just-command:
+        type: string
+        description: Just command to run (possibly with arguments)
+        required: true
+      full-git-history:
+        type: boolean
+        description: Whether to fetch full git history rather than just current HEAD
+        default: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: ${{ inputs.full-git-history && '0' || '1' }}
+
+      - name: Install mise and tools
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          cache: false
+
+      - name: Ensure just is available
+        run: command -v just || mise install just@latest
+
+      - name: Run just
+        env:
+          JUST_COMMAND: ${{ inputs.just-command }}
+        run: |
+          read -ra cmd <<< "$JUST_COMMAND"
+          just "${cmd[@]}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,34 +14,12 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0  # need all history for copyright headers
-          persist-credentials: false
-
-      - name: Install mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-
-      - name: Lint
-        run: |
-          just lint
+    uses: ./.github/workflows/_run-just.yaml
+    with:
+      just-command: lint
+      full-git-history: true  # copyright headers need it
 
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Install mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        with:
-          cache: false
-
-      - name: Test
-        run: |
-          just test
+    uses: ./.github/workflows/_run-just.yaml
+    with:
+      just-command: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,12 +14,14 @@ permissions:
 
 jobs:
   lint:
+    name: lint
     uses: ./.github/workflows/_run-just.yaml
     with:
       just-command: lint
       full-git-history: true  # copyright headers need it
 
   test:
+    name: test
     uses: ./.github/workflows/_run-just.yaml
     with:
       just-command: test


### PR DESCRIPTION
### what

add reusable workflow to install tools and run just, consolidating common
pattern in CI jobs

### why

reduce duplication

### testing

testing in CI

### docs

n/a
