### PR TITLE
fix: account discovery graphql field names [ENG-7965] (fixes #240, #241)

### DIFF
--- a/internal/api/account_discovery.go
+++ b/internal/api/account_discovery.go
@@ -26,25 +26,25 @@ type AccountDiscovery struct {
 }
 
 type accountDiscoveryAWSConfig struct {
-	OrgID         string `graphql:"orgId"`
+	OrgID         string `graphql:"orgID"`
 	OrgRole       string `graphql:"orgRole"`
 	MemberRole    string `graphql:"memberRole"`
 	CustodianRole string `graphql:"custodianRole"`
 }
 
 type accountDiscoveryAzureConfig struct {
-	TenantID string `graphql:"tenantId"`
-	ClientID string `graphql:"clientId"`
+	TenantID string `graphql:"tenantID"`
+	ClientID string `graphql:"clientID"`
 }
 
 type accountDiscoveryGCPConfig struct {
 	ClientEmail      string   `graphql:"clientEmail"`
-	ClientID         string   `graphql:"clientId"`
-	OrgID            string   `graphql:"orgId"`
-	RootFolderIDs    []string `graphql:"rootFolderIds"`
-	ExcludeFolderIDs []string `graphql:"excludeFolderIds"`
-	ProjectID        string   `graphql:"projectId"`
-	PrivateKeyID     string   `graphql:"privateKeyId"`
+	ClientID         string   `graphql:"clientID"`
+	OrgID            string   `graphql:"orgID"`
+	RootFolderIDs    []string `graphql:"rootFolderIDs"`
+	ExcludeFolderIDs []string `graphql:"excludeFolderIDs"`
+	ProjectID        string   `graphql:"projectID"`
+	PrivateKeyID     string   `graphql:"privateKeyID"`
 }
 
 // AccountDiscoveryAWSInput is the input to create or update an AWS account discovery.


### PR DESCRIPTION
[ENG-7965](https://stacklet.atlassian.net/browse/ENG-7965)

### what

Fix graphql tag for some structure fields related to account discovery.

### why

Some graphql fields ending with "ID" were erroneously changed to "Id" in
11febf8ef1e9f278025a2614a6ef0c31c4c8d6fa, causing corresponding API calls to fail

### testing

tested locally

### docs

n/a


[ENG-7965]: https://stacklet.atlassian.net/browse/ENG-7965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ