### PR TITLE
feat: include message in error for API call returning 400 [ENG-7965]

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -5,10 +5,12 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -53,13 +55,15 @@ func newClient(ctx context.Context, config ClientConfig) *client {
 	logBody := tfLog == hclog.Debug || tfLog == hclog.Trace
 
 	httpClient := &http.Client{
-		Transport: &authTransport{
-			APIKey:  config.APIKey,
-			Version: config.Version,
-			Base: &logTransport{
-				Ctx:     ctx,
-				Base:    http.DefaultTransport,
-				LogBody: logBody,
+		Transport: &errorTransport{
+			Base: &authTransport{
+				APIKey:  config.APIKey,
+				Version: config.Version,
+				Base: &logTransport{
+					Ctx:     ctx,
+					Base:    http.DefaultTransport,
+					LogBody: logBody,
+				},
 			},
 		},
 	}
@@ -141,6 +145,40 @@ func (t *logTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, reqErr
 }
 
+// errorTransport is an http.Transport that converts 400 responses with a
+// GraphQL-style error payload into Go errors, so callers see the actual
+// error messages rather than a generic "400 Bad Request".
+type errorTransport struct {
+	Base http.RoundTripper
+}
+
+func (t *errorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.Base.RoundTrip(req)
+	if err != nil || resp == nil || resp.StatusCode != http.StatusBadRequest {
+		return resp, err
+	}
+
+	content, err := decodeResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var payload struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if json.Unmarshal([]byte(content), &payload) == nil && len(payload.Errors) > 0 {
+		msgs := make([]string, len(payload.Errors))
+		for i, e := range payload.Errors {
+			msgs[i] = e.Message
+		}
+		return nil, apiError{Kind: "API Error", Detail: strings.Join(msgs, "\n")}
+	}
+
+	return resp, nil
+}
+
 func decodeRequestBody(req *http.Request) (string, error) {
 	if req.Body == nil || req.Body == http.NoBody {
 		return "", nil
@@ -159,6 +197,7 @@ func decodeResponseBody(resp *http.Response) (string, error) {
 	if resp.Body == nil || resp.Body == http.NoBody {
 		return "", nil
 	}
+	defer resp.Body.Close()
 
 	content, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -58,4 +59,54 @@ func TestAuthorizationHeader(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedAuth, capturedAuth)
+}
+
+func TestErrorTransport_400WithGraphQLErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"field not found"},{"message":"invalid type"}]}`))
+	}))
+	defer server.Close()
+
+	transport := &errorTransport{Base: http.DefaultTransport}
+	client := &http.Client{Transport: transport}
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	resp, err := client.Do(req)
+
+	assert.Nil(t, resp)
+	assert.EqualError(t, err, "Get \""+server.URL+"\": field not found\ninvalid type")
+}
+
+func TestErrorTransport_400WithoutGraphQLErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer server.Close()
+
+	transport := &errorTransport{Base: http.DefaultTransport}
+	client := &http.Client{Transport: transport}
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	resp, err := client.Do(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "not json", string(body))
+}
+
+func TestErrorTransport_NonBadRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer server.Close()
+
+	transport := &errorTransport{Base: http.DefaultTransport}
+	client := &http.Client{Transport: transport}
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	resp, err := client.Do(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }

--- a/internal/api/error.go
+++ b/internal/api/error.go
@@ -4,6 +4,8 @@ package api
 
 import (
 	"context"
+	"errors"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -26,6 +28,10 @@ func (e apiError) Error() string {
 
 // newAPIError returns an apiError from an error.
 func newAPIError(err error) apiError {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return newAPIError(urlErr.Err)
+	}
 	return apiError{Kind: "API Error", Detail: err.Error()}
 }
 

--- a/internal/api/error_test.go
+++ b/internal/api/error_test.go
@@ -1,0 +1,30 @@
+// Copyright Stacklet, Inc. 2025, 2026
+
+package api
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAPIError_URLError(t *testing.T) {
+	// http.Client.Do wraps transport errors in *url.Error. Without unwrapping,
+	// the diagnostic would show `Post "https://...": field not found` instead of
+	// the clean inner message.
+	inner := errors.New("field not found; invalid type")
+	urlErr := &url.Error{Op: "Post", URL: "https://api.example.com/graphql", Err: inner}
+	err := newAPIError(urlErr)
+
+	assert.Equal(t, "API Error", err.Summary())
+	assert.Equal(t, "field not found; invalid type", err.Error())
+}
+
+func TestNewAPIError_PlainError(t *testing.T) {
+	err := newAPIError(errors.New("something went wrong"))
+
+	assert.Equal(t, "API Error", err.Summary())
+	assert.Equal(t, "something went wrong", err.Error())
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Generate documentation.
-//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-dir .. // generate-docs
+//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-dir .. --provider-name terraform-provider-stacklet // generate-docs
 
 // Validate generated documentation.
-//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs validate --provider-dir .. // validate-docs
+//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs validate --provider-dir .. --provider-name terraform-provider-stacklet // validate-docs


### PR DESCRIPTION
[ENG-7965](https://stacklet.atlassian.net/browse/ENG-7965)

### what

extract the error messages from the JSON payload on 400 errors in API calls

### why

give meaningful information about the failure

### testing

tested locally, added test

### docs

n/a


[ENG-7965]: https://stacklet.atlassian.net/browse/ENG-7965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ