### PR TITLE
fix: resolve role assignment user group principals [ENG-8192]

### DIFF
--- a/docs/data-sources/role_assignments.md
+++ b/docs/data-sources/role_assignments.md
@@ -3,12 +3,12 @@
 page_title: "stacklet_role_assignments Data Source - terraform-provider-stacklet"
 subcategory: ""
 description: |-
-  Retrieve role assignments for a specific target. This data source allows you to query which principals (users or SSO groups) have been granted roles on a particular target (system, account group, policy collection, or repository).
+  Retrieve role assignments for a specific target. This data source allows you to query which principals (users or user groups) have been granted roles on a particular target (system, account group, policy collection, or repository).
 ---
 
 # stacklet_role_assignments (Data Source)
 
-Retrieve role assignments for a specific target. This data source allows you to query which principals (users or SSO groups) have been granted roles on a particular target (system, account group, policy collection, or repository).
+Retrieve role assignments for a specific target. This data source allows you to query which principals (users or user groups) have been granted roles on a particular target (system, account group, policy collection, or repository).
 
 ## Example Usage
 

--- a/docs/resources/role_assignment.md
+++ b/docs/resources/role_assignment.md
@@ -3,12 +3,12 @@
 page_title: "stacklet_role_assignment Resource - terraform-provider-stacklet"
 subcategory: ""
 description: |-
-  Manages role assignments for principals (users or SSO groups) on targets (system, account groups, policy collections, or repositories). Role assignments grant specific permissions to principals on target resources.
+  Manages role assignments for principals (users or user groups) on targets (system, account groups, policy collections, or repositories). Role assignments grant specific permissions to principals on target resources.
 ---
 
 # stacklet_role_assignment (Resource)
 
-Manages role assignments for principals (users or SSO groups) on targets (system, account groups, policy collections, or repositories). Role assignments grant specific permissions to principals on target resources.
+Manages role assignments for principals (users or user groups) on targets (system, account groups, policy collections, or repositories). Role assignments grant specific permissions to principals on target resources.
 
 ## Example Usage
 
@@ -16,11 +16,6 @@ Manages role assignments for principals (users or SSO groups) on targets (system
 # Fetch user information
 data "stacklet_user" "example_user" {
   username = "example-user"
-}
-
-# Fetch SSO group information
-data "stacklet_sso_group" "example_group" {
-  name = "Engineering"
 }
 
 # Fetch account group
@@ -35,10 +30,10 @@ resource "stacklet_role_assignment" "system_admin" {
   target    = "system:all"
 }
 
-# Assign a role to an SSO group on a specific target resource
-resource "stacklet_role_assignment" "group_viewer" {
+# Assign a role to a user on a specific target resource
+resource "stacklet_role_assignment" "account_group_viewer" {
   role_name = "viewer"
-  principal = data.stacklet_sso_group.example_group.role_assignment_principal
+  principal = data.stacklet_user.example_user.role_assignment_principal
   target    = data.stacklet_account_group.example.role_assignment_target
 }
 ```
@@ -48,7 +43,7 @@ resource "stacklet_role_assignment" "group_viewer" {
 
 ### Required
 
-- `principal` (String) An opaque principal identifier. Use the 'role_assignment_principal' computed attribute from user or SSO group resources.
+- `principal` (String) An opaque principal identifier. Use the 'role_assignment_principal' computed attribute from user or user group resources.
 - `role_name` (String) The name of the role to assign. Use the stacklet_role data source to find available roles.
 - `target` (String) An opaque target identifier. Use the 'role_assignment_target' computed attribute from account group, policy collection, or repository resources.
 

--- a/examples/resources/stacklet_role_assignment/resource.tf
+++ b/examples/resources/stacklet_role_assignment/resource.tf
@@ -3,11 +3,6 @@ data "stacklet_user" "example_user" {
   username = "example-user"
 }
 
-# Fetch SSO group information
-data "stacklet_sso_group" "example_group" {
-  name = "Engineering"
-}
-
 # Fetch account group
 data "stacklet_account_group" "example" {
   uuid = "00000000-0000-0000-0000-000000000000"
@@ -20,9 +15,9 @@ resource "stacklet_role_assignment" "system_admin" {
   target    = "system:all"
 }
 
-# Assign a role to an SSO group on a specific target resource
-resource "stacklet_role_assignment" "group_viewer" {
+# Assign a role to a user on a specific target resource
+resource "stacklet_role_assignment" "account_group_viewer" {
   role_name = "viewer"
-  principal = data.stacklet_sso_group.example_group.role_assignment_principal
+  principal = data.stacklet_user.example_user.role_assignment_principal
   target    = data.stacklet_account_group.example.role_assignment_target
 }

--- a/internal/acceptance_tests/recordings/TestAccRoleAssignmentResource_AccountGroup.json
+++ b/internal/acceptance_tests/recordings/TestAccRoleAssignmentResource_AccountGroup.json
@@ -69,10 +69,10 @@
       }
     }
   ],
-  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}}}}:{\"input\":{\"grant\":[{\"principal\":\"user:53\",\"roleName\":\"editor\",\"target\":\"account-group:8d7f1a4b-02ab-4986-9a4c-975ae38a79a5\"}]}}": [
+  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}}}}:{\"input\":{\"grant\":[{\"principal\":\"user:53\",\"roleName\":\"editor\",\"target\":\"account-group:8d7f1a4b-02ab-4986-9a4c-975ae38a79a5\"}]}}": [
     {
       "request": {
-        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}}}}",
+        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}}}}",
         "variables": {
           "input": {
             "grant": [
@@ -118,10 +118,10 @@
       }
     }
   ],
-  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}}}}:{\"input\":{\"grant\":[{\"principal\":\"user:53\",\"roleName\":\"viewer\",\"target\":\"account-group:8d7f1a4b-02ab-4986-9a4c-975ae38a79a5\"}]}}": [
+  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}}}}:{\"input\":{\"grant\":[{\"principal\":\"user:53\",\"roleName\":\"viewer\",\"target\":\"account-group:8d7f1a4b-02ab-4986-9a4c-975ae38a79a5\"}]}}": [
     {
       "request": {
-        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}}}}",
+        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}}}}",
         "variables": {
           "input": {
             "grant": [
@@ -268,10 +268,10 @@
       }
     }
   ],
-  "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}:{\"cursor\":\"\",\"filterElement\":{\"multiple\":{\"operands\":[{\"single\":{\"name\":\"role-name\",\"operator\":\"equals\",\"value\":\"editor\"}},{\"single\":{\"name\":\"target\",\"operator\":\"equals\",\"value\":\"account-group:8d7f1a4b-02ab-4986-9a4c-975ae38a79a5\"}}],\"operator\":\"AND\"}},\"pageSize\":1}": [
+  "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}:{\"cursor\":\"\",\"filterElement\":{\"multiple\":{\"operands\":[{\"single\":{\"name\":\"role-name\",\"operator\":\"equals\",\"value\":\"editor\"}},{\"single\":{\"name\":\"target\",\"operator\":\"equals\",\"value\":\"account-group:8d7f1a4b-02ab-4986-9a4c-975ae38a79a5\"}}],\"operator\":\"AND\"}},\"pageSize\":1}": [
     {
       "request": {
-        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
+        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
         "variables": {
           "cursor": "",
           "filterElement": {
@@ -335,7 +335,7 @@
     },
     {
       "request": {
-        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
+        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
         "variables": {
           "cursor": "",
           "filterElement": {
@@ -398,10 +398,10 @@
       }
     }
   ],
-  "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}:{\"cursor\":\"\",\"filterElement\":{\"multiple\":{\"operands\":[{\"single\":{\"name\":\"role-name\",\"operator\":\"equals\",\"value\":\"viewer\"}},{\"single\":{\"name\":\"target\",\"operator\":\"equals\",\"value\":\"account-group:8d7f1a4b-02ab-4986-9a4c-975ae38a79a5\"}}],\"operator\":\"AND\"}},\"pageSize\":1}": [
+  "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}:{\"cursor\":\"\",\"filterElement\":{\"multiple\":{\"operands\":[{\"single\":{\"name\":\"role-name\",\"operator\":\"equals\",\"value\":\"viewer\"}},{\"single\":{\"name\":\"target\",\"operator\":\"equals\",\"value\":\"account-group:8d7f1a4b-02ab-4986-9a4c-975ae38a79a5\"}}],\"operator\":\"AND\"}},\"pageSize\":1}": [
     {
       "request": {
-        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
+        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
         "variables": {
           "cursor": "",
           "filterElement": {
@@ -462,7 +462,7 @@
     },
     {
       "request": {
-        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
+        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
         "variables": {
           "cursor": "",
           "filterElement": {
@@ -523,7 +523,7 @@
     },
     {
       "request": {
-        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
+        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
         "variables": {
           "cursor": "",
           "filterElement": {
@@ -584,7 +584,7 @@
     },
     {
       "request": {
-        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
+        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
         "variables": {
           "cursor": "",
           "filterElement": {
@@ -645,7 +645,7 @@
     },
     {
       "request": {
-        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
+        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
         "variables": {
           "cursor": "",
           "filterElement": {

--- a/internal/acceptance_tests/recordings/TestAccRoleAssignmentResource_SSOGroup.json
+++ b/internal/acceptance_tests/recordings/TestAccRoleAssignmentResource_SSOGroup.json
@@ -24,10 +24,10 @@
       }
     }
   ],
-  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}}}}:{\"input\":{\"grant\":[{\"principal\":\"sso-group:21\",\"roleName\":\"viewer\",\"target\":\"system:all\"}]}}": [
+  "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}}}}:{\"input\":{\"grant\":[{\"principal\":\"sso-group:21\",\"roleName\":\"viewer\",\"target\":\"system:all\"}]}}": [
     {
       "request": {
-        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}}}}",
+        "query": "mutation ($input:UpdateRoleAssignmentInput!){updateRoleAssignment(input: $input){grant{errorMessage,roleAssignment{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}}}}",
         "variables": {
           "input": {
             "grant": [
@@ -136,10 +136,10 @@
       }
     }
   ],
-  "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}:{\"cursor\":\"\",\"filterElement\":{\"multiple\":{\"operands\":[{\"single\":{\"name\":\"role-name\",\"operator\":\"equals\",\"value\":\"viewer\"}},{\"single\":{\"name\":\"target\",\"operator\":\"equals\",\"value\":\"system:all\"}}],\"operator\":\"AND\"}},\"pageSize\":1}": [
+  "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}:{\"cursor\":\"\",\"filterElement\":{\"multiple\":{\"operands\":[{\"single\":{\"name\":\"role-name\",\"operator\":\"equals\",\"value\":\"viewer\"}},{\"single\":{\"name\":\"target\",\"operator\":\"equals\",\"value\":\"system:all\"}}],\"operator\":\"AND\"}},\"pageSize\":1}": [
     {
       "request": {
-        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
+        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
         "variables": {
           "cursor": "",
           "filterElement": {
@@ -200,7 +200,7 @@
     },
     {
       "request": {
-        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
+        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
         "variables": {
           "cursor": "",
           "filterElement": {

--- a/internal/acceptance_tests/recordings/TestAccRoleAssignmentsDataSource.json
+++ b/internal/acceptance_tests/recordings/TestAccRoleAssignmentsDataSource.json
@@ -1,8 +1,8 @@
 {
-  "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}:{\"cursor\":\"\",\"filterElement\":{\"single\":{\"name\":\"target\",\"operator\":\"equals\",\"value\":\"system:all\"}},\"pageSize\":1}": [
+  "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}:{\"cursor\":\"\",\"filterElement\":{\"single\":{\"name\":\"target\",\"operator\":\"equals\",\"value\":\"system:all\"}},\"pageSize\":1}": [
     {
       "request": {
-        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
+        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
         "variables": {
           "cursor": "",
           "filterElement": {
@@ -57,7 +57,7 @@
     },
     {
       "request": {
-        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
+        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
         "variables": {
           "cursor": "",
           "filterElement": {
@@ -112,7 +112,7 @@
     },
     {
       "request": {
-        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
+        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
         "variables": {
           "cursor": "",
           "filterElement": {
@@ -166,10 +166,10 @@
       }
     }
   ],
-  "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}:{\"cursor\":\"eJw9yDEKwCAMAMCvlMz2RSISNENoTIPGwd9XKLgdF8E6a2FDyYqNQn+FfpE6+8q+7HhOrhCuCMOxPEJ+Y22su+BgrOHUtnSKpPQB+x0jFA==\",\"filterElement\":{\"single\":{\"name\":\"target\",\"operator\":\"equals\",\"value\":\"system:all\"}},\"pageSize\":1}": [
+  "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}:{\"cursor\":\"eJw9yDEKwCAMAMCvlMz2RSISNENoTIPGwd9XKLgdF8E6a2FDyYqNQn+FfpE6+8q+7HhOrhCuCMOxPEJ+Y22su+BgrOHUtnSKpPQB+x0jFA==\",\"filterElement\":{\"single\":{\"name\":\"target\",\"operator\":\"equals\",\"value\":\"system:all\"}},\"pageSize\":1}": [
     {
       "request": {
-        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
+        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
         "variables": {
           "cursor": "eJw9yDEKwCAMAMCvlMz2RSISNENoTIPGwd9XKLgdF8E6a2FDyYqNQn+FfpE6+8q+7HhOrhCuCMOxPEJ+Y22su+BgrOHUtnSKpPQB+x0jFA==",
           "filterElement": {
@@ -224,7 +224,7 @@
     },
     {
       "request": {
-        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
+        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
         "variables": {
           "cursor": "eJw9yDEKwCAMAMCvlMz2RSISNENoTIPGwd9XKLgdF8E6a2FDyYqNQn+FfpE6+8q+7HhOrhCuCMOxPEJ+Y22su+BgrOHUtnSKpPQB+x0jFA==",
           "filterElement": {
@@ -279,7 +279,7 @@
     },
     {
       "request": {
-        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{... on User{roleAssignmentPrincipal},... on SSOGroup{roleAssignmentPrincipal}},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
+        "query": "query ($cursor:String!$filterElement:FilterElementInput!$pageSize:Int!){roleAssignments(first: $pageSize, after: $cursor, filterElement: $filterElement){edges{node{id,role{id,name,permissions,system},principal{roleAssignmentPrincipal},target{roleAssignmentTarget,... on RoleScope{roleAssignmentTarget},... on AccountGroup{roleAssignmentTarget},... on PolicyCollection{roleAssignmentTarget},... on Repository{roleAssignmentTarget},... on RepositoryConfig{roleAssignmentTarget}}}},pageInfo{hasNextPage,endCursor}}}",
         "variables": {
           "cursor": "eJw9yDEKwCAMAMCvlMz2RSISNENoTIPGwd9XKLgdF8E6a2FDyYqNQn+FfpE6+8q+7HhOrhCuCMOxPEJ+Y22su+BgrOHUtnSKpPQB+x0jFA==",
           "filterElement": {

--- a/internal/api/role_assignment.go
+++ b/internal/api/role_assignment.go
@@ -17,26 +17,17 @@ type RoleAssignment struct {
 	Target    roleTarget    `graphql:"target"`
 }
 
-// rolePrincipalPrincipal contains the opaque roleAssignmentPrincipal string.
-type rolePrincipalPrincipal struct {
-	RoleAssignmentPrincipal string `graphql:"roleAssignmentPrincipal"`
-}
-
-// rolePrincipal represents the GraphQL union type for RolePrincipal.
+// rolePrincipal represents the RolePrincipal GraphQL interface. The opaque
+// roleAssignmentPrincipal is declared on the interface itself, so selecting it
+// directly resolves for any concrete principal type (users and user groups)
+// without per-type inline fragments.
 type rolePrincipal struct {
-	User     *rolePrincipalPrincipal `graphql:"... on User"`
-	SSOGroup *rolePrincipalPrincipal `graphql:"... on SSOGroup"`
+	RoleAssignmentPrincipal string `graphql:"roleAssignmentPrincipal"`
 }
 
 // GetPrincipal extracts the opaque principal identifier string.
 func (r *RoleAssignment) GetPrincipal() string {
-	if r.Principal.User != nil {
-		return r.Principal.User.RoleAssignmentPrincipal
-	}
-	if r.Principal.SSOGroup != nil {
-		return r.Principal.SSOGroup.RoleAssignmentPrincipal
-	}
-	return ""
+	return r.Principal.RoleAssignmentPrincipal
 }
 
 // roleTarget represents the GraphQL union type for target entities.

--- a/internal/datasources/role_assignments.go
+++ b/internal/datasources/role_assignments.go
@@ -24,7 +24,7 @@ func (d *roleAssignmentsDataSource) Metadata(_ context.Context, req datasource.M
 
 func (d *roleAssignmentsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Retrieve role assignments for a specific target. This data source allows you to query which principals (users or SSO groups) have been granted roles on a particular target (system, account group, policy collection, or repository).",
+		Description: "Retrieve role assignments for a specific target. This data source allows you to query which principals (users or user groups) have been granted roles on a particular target (system, account group, policy collection, or repository).",
 		Attributes: map[string]schema.Attribute{
 			"target": schema.StringAttribute{
 				Description: "An opaque target identifier to query role assignments for. Use the 'role_assignment_target' attribute from resource outputs.",

--- a/internal/resources/role_assignment.go
+++ b/internal/resources/role_assignment.go
@@ -31,7 +31,7 @@ func (r *roleAssignmentResource) Metadata(_ context.Context, req resource.Metada
 
 func (r *roleAssignmentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Manages role assignments for principals (users or SSO groups) on targets (system, account groups, policy collections, or repositories). Role assignments grant specific permissions to principals on target resources.",
+		Description: "Manages role assignments for principals (users or user groups) on targets (system, account groups, policy collections, or repositories). Role assignments grant specific permissions to principals on target resources.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The unique identifier of the role assignment.",
@@ -48,7 +48,7 @@ func (r *roleAssignmentResource) Schema(_ context.Context, _ resource.SchemaRequ
 				},
 			},
 			"principal": schema.StringAttribute{
-				Description: "An opaque principal identifier. Use the 'role_assignment_principal' computed attribute from user or SSO group resources.",
+				Description: "An opaque principal identifier. Use the 'role_assignment_principal' computed attribute from user or user group resources.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),


### PR DESCRIPTION
[ENG-8192](https://stacklet.atlassian.net/browse/ENG-8192)

### what

Resolve role-assignment principals by selecting the `roleAssignmentPrincipal`
field directly on the `RolePrincipal` GraphQL interface, instead of matching
specific principal types with per-type inline fragments.

### why

Role-assignment principals backed by a group now resolve to the GraphQL
`UserGroup` type. The provider matched only specific principal types via inline
fragments and didn't handle user groups, so a user group principal decoded to an
empty string — and any role assignment with a group principal read back as
missing (perpetual drift, failed imports).

`roleAssignmentPrincipal` is declared on the `RolePrincipal` interface, so
selecting it directly resolves for users and user groups alike. This mirrors the
existing `roleTarget`/`GetTarget()` pattern already used for targets in the same
file.

### testing

`just test` (full replay suite), `just build`, `just lint` all pass. The three
affected recordings were updated to the new query shape; responses are unchanged
because inline fragments flatten in GraphQL responses, so no re-recording was
needed.

### docs

Regenerated (`just docs`); role_assignment resource/data-source descriptions now
refer to "users or user groups".

[ENG-7923]: https://stacklet.atlassian.net/browse/ENG-7923


[ENG-8192]: https://stacklet.atlassian.net/browse/ENG-8192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ